### PR TITLE
Fix configured default params

### DIFF
--- a/lib/lhc/endpoint.rb
+++ b/lib/lhc/endpoint.rb
@@ -22,6 +22,11 @@ class LHC::Endpoint
     end
   end
 
+  # Endpoint options are immutable
+  def options
+    @options.deep_dup
+  end
+
   # Removes keys from provided params hash
   # when they are used for interpolation.
   def remove_interpolated_params!(params)

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -71,9 +71,12 @@ class LHC::Request
   # Get configured endpoint and use it for doing the request.
   # Explicit request options are overriding configured options.
   def use_configured_endpoint!
-    return unless (endpoint = LHC.config.endpoints[options[:url]])
-    options.deep_merge!(endpoint.options.deep_merge(options))
-    options[:url] = endpoint.url
+    return unless (endpoint = LHC.config.endpoints[self.options[:url]])
+    # explicit options override endpoint options
+    new_options = endpoint.options.deep_merge(self.options)
+    # set new options
+    self.options = new_options
+    self.options[:url] = endpoint.url
   end
 
   # Generates URL from a URL template

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -72,8 +72,7 @@ class LHC::Request
   # Explicit request options are overriding configured options.
   def use_configured_endpoint!
     return unless (endpoint = LHC.config.endpoints[options[:url]])
-    endpoint.options.deep_merge!(options)
-    options.deep_merge!(endpoint.options)
+    options.deep_merge!(endpoint.options.deep_merge(options))
     options[:url] = endpoint.url
   end
 

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -71,7 +71,8 @@ class LHC::Request
   # Get configured endpoint and use it for doing the request.
   # Explicit request options are overriding configured options.
   def use_configured_endpoint!
-    return unless (endpoint = LHC.config.endpoints[self.options[:url]])
+    endpoint = LHC.config.endpoints[self.options[:url]]
+    return unless endpoint
     # explicit options override endpoint options
     new_options = endpoint.options.deep_merge(self.options)
     # set new options

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -12,7 +12,7 @@ class LHC::Request
   attr_accessor :response, :options, :raw
 
   def initialize(options, self_executing = true)
-    self.options = options.deep_dup
+    self.options = options.deep_dup || {}
     use_configured_endpoint!
     generate_url_from_template!
     self.iprocessor = LHC::InterceptorProcessor.new(self)

--- a/spec/config/endpoints_spec.rb
+++ b/spec/config/endpoints_spec.rb
@@ -46,4 +46,19 @@ describe LHC do
       expect(LHC.config.endpoints[:datastore].url).to eq 'http://datastore.lb-service'
     end
   end
+
+  context 'configured enpoints with default params' do
+
+    before(:each) do
+      LHC.config.endpoint(:telemarketers, 'http://datastore.lb-service/v2/spamnumbers?order_by=-user_frequency&swiss_number=true&offset=0&limit=:limit', params: { limit: 200 })
+      stub_request(:get, 'http://datastore.lb-service/v2/spamnumbers?limit=200&offset=0&order_by=-user_frequency&swiss_number=true')
+        .to_return(status: 200)
+    end
+
+    it 'is possible to call them multiple times with default params' do
+      LHC.get(:telemarketers)
+      LHC.get(:telemarketers)
+      LHC.get(:telemarketers)
+    end
+  end
 end


### PR DESCRIPTION
Bug: Configured endpoints with default params can just be called once. After that the endpoints options are empty.

Reason: Endpoints options should not be mutated. I made them immutable in order to ensure this.

### PATCH AHEAD
