### PR TITLE
Allow json shortcut methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Available are `get`, `post`, `put` & `delete`.
 
 Other methods are available using `LHC.request(options)`.
 
-## Do request that usa a particular format
+## Formats: like json etc.
 
 You can use any of the basic methods in combination with a format like `json`:
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ Available are `get`, `post`, `put` & `delete`.
 
 Other methods are available using `LHC.request(options)`.
 
+## Do request that usa a particular format
+
+You can use any of the basic methods in combination with a format like `json`:
+
+```ruby
+LHC.json.get(options)
+```
+
+Currently supported formats: `json`
+
 ## A request from scratch
 
 ```ruby

--- a/lib/lhc.rb
+++ b/lib/lhc.rb
@@ -2,6 +2,7 @@ Dir[File.dirname(__FILE__) + '/lhc/concerns/lhc/*.rb'].sort.each {|file| require
 
 module LHC
   include BasicMethods
+  include Formats
 
   def self.config
     LHC::Config.instance

--- a/lib/lhc/concerns/lhc/formats.rb
+++ b/lib/lhc/concerns/lhc/formats.rb
@@ -1,0 +1,13 @@
+module LHC
+
+  module Formats
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+
+      def json
+        JsonFormat
+      end
+    end
+  end
+end

--- a/lib/lhc/formats/json.rb
+++ b/lib/lhc/formats/json.rb
@@ -1,0 +1,10 @@
+module JsonFormat
+
+  include LHC::BasicMethods
+
+  def self.request(options)
+    options[:headers] ||= {}
+    options[:headers]['Content-Type'] = 'application/json'
+    response = super(options)
+  end
+end

--- a/lib/lhc/response.rb
+++ b/lib/lhc/response.rb
@@ -16,7 +16,12 @@ class LHC::Response
   # Access response data.
   # Cache parsing.
   def data
-    @data ||= JSON.parse(raw.body, object_class: OpenStruct)
+    @data ||= case format
+      when :json
+        JSON.parse(raw.body, object_class: OpenStruct)
+      else # default is json
+        JSON.parse(raw.body, object_class: OpenStruct)
+    end
     @data
   end
 
@@ -52,5 +57,11 @@ class LHC::Response
   private
 
   attr_accessor :raw
+
+  def format
+    headers = {}
+    headers = request.options.fetch(:headers, {}) if request && request.options
+    return :json if headers['Content-Type'] == 'application/json'
+  end
 
 end

--- a/spec/basic_methods/get_spec.rb
+++ b/spec/basic_methods/get_spec.rb
@@ -34,4 +34,17 @@ describe LHC do
       expect(response.headers).to be
     end
   end
+
+  context 'get json' do
+
+    before(:each) do
+      stub_request(:get, 'http://datastore/v2/feedbacks').with(headers: {'Content-Type' => 'application/json'})
+        .to_return(body: {some: 'json'}.to_json)
+    end
+
+    it 'requests json and parses response body' do
+      data = LHC.json.get('http://datastore/v2/feedbacks').data
+      expect(data.some).to eq 'json'
+    end
+  end
 end


### PR DESCRIPTION
Shortcut should
- Request JSON
- Parse json when `.data` is requested

Solves: https://github.com/local-ch/lhc/issues/15