### PR TITLE
enable follow redirect and effective url

### DIFF
--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -7,7 +7,7 @@ require 'active_support/core_ext/object/deep_dup'
 # and it communicates with interceptors.
 class LHC::Request
 
-  TYPHOEUS_OPTIONS = [:params, :method, :body, :headers]
+  TYPHOEUS_OPTIONS = [:params, :method, :body, :headers, :follow_location]
 
   attr_accessor :response, :options, :raw
 

--- a/lib/lhc/response.rb
+++ b/lib/lhc/response.rb
@@ -25,6 +25,10 @@ class LHC::Response
     @data
   end
 
+  def effective_url
+    raw.effective_url
+  end
+
   def body
     raw.body
   end

--- a/spec/response/effective_url_spec.rb
+++ b/spec/response/effective_url_spec.rb
@@ -5,7 +5,7 @@ describe LHC::Response do
   context 'effective_url' do
 
     let(:effective_url) do
-      { 'effective_url' => 'https://local.ch' }
+      { 'effective_url' => 'https://www.local.ch' }
     end
 
     let(:raw_response) { OpenStruct.new({ effective_url: effective_url }) }

--- a/spec/response/effective_url_spec.rb
+++ b/spec/response/effective_url_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe LHC::Response do
+
+  context 'effective_url' do
+
+    let(:effective_url) do
+      { 'effective_url' => 'https://local.ch' }
+    end
+
+    let(:raw_response) { OpenStruct.new({ effective_url: effective_url }) }
+
+    it 'provides effective_url' do
+      response = LHC::Response.new(raw_response, nil)
+      expect(response.effective_url).to eq effective_url
+    end
+  end
+end

--- a/spec/response/effective_url_spec.rb
+++ b/spec/response/effective_url_spec.rb
@@ -4,11 +4,9 @@ describe LHC::Response do
 
   context 'effective_url' do
 
-    let(:effective_url) do
-      { 'effective_url' => 'https://www.local.ch' }
-    end
+    let(:effective_url) { 'https://www.local.ch' }
 
-    let(:raw_response) { OpenStruct.new({ effective_url: effective_url }) }
+    let(:raw_response) { OpenStruct.new(effective_url: effective_url) }
 
     it 'provides effective_url' do
       response = LHC::Response.new(raw_response, nil)


### PR DESCRIPTION
- enables the option `follow_location`
- enables the method `effective_url` for responses

Both allows you to follow redirects and access the effective url in the end.

As request here https://github.com/local-ch/lhc/issues/38