### PR TITLE
! consider body when compiling/generating urls

### DIFF
--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -83,7 +83,12 @@ class LHC::Request
   # Generates URL from a URL template
   def generate_url_from_template!
     endpoint = LHC::Endpoint.new(options[:url])
-    options[:url] = endpoint.compile(options[:params])
+    params = if options[:body] && options[:body].length && (options[:headers] || {}).fetch('Content-Type', nil) == 'application/json'
+      JSON.parse(options[:body]).merge(options[:params] || {}).deep_symbolize_keys
+    else
+      options[:params]
+    end
+    options[:url] = endpoint.compile(params)
     endpoint.remove_interpolated_params!(options[:params])
   end
 

--- a/spec/request/url_patterns_spec.rb
+++ b/spec/request/url_patterns_spec.rb
@@ -16,4 +16,9 @@ describe LHC::Request do
     stub_request(:get, 'http://datastore:8080/v2/feedbacks/123')
     LHC.get('http://datastore:8080/v2/feedbacks/:id', params:{id: 123})
   end
+
+  it 'considers body when compiling urls' do
+    stub_request(:post, "http://datastore:8080/v2/places/123")
+    LHC.json.post('http://datastore:8080/v2/places/:id', body: {id: 123}.to_json)
+  end
 end


### PR DESCRIPTION
The request body was not considered when trying to compile url patterns "datastore/v2/places/:id".
It was not considering data from the body to construct those urls.