### PR TITLE
! endpoint matching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,18 @@ Lint/IneffectiveAccessModifier:
 
 Rails:
   Enabled: false
+
+RSpec/AnyInstance:
+  Enabled: false
+
+RSpec/NotToNo:
+  Enabled: false
+
+RSpec/NotToNo:
+  Enabled: false
+
+RSpec/DescribedClass:
+  Enabled: false
+
+Style/Lambda:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,9 +15,6 @@ RSpec/AnyInstance:
 RSpec/NotToNo:
   Enabled: false
 
-RSpec/NotToNo:
-  Enabled: false
-
 RSpec/DescribedClass:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,9 +12,6 @@ Rails:
 RSpec/AnyInstance:
   Enabled: false
 
-RSpec/NotToNo:
-  Enabled: false
-
 RSpec/DescribedClass:
   Enabled: false
 

--- a/lib/lhc/endpoint.rb
+++ b/lib/lhc/endpoint.rb
@@ -62,7 +62,9 @@ class LHC::Endpoint
   # Returns true if concrete url is covered by the template
   # Example: :datastore/contracts/:id == http://local.ch/contracts/1
   def self.match?(url, template)
-    regexp = template.gsub %r{((?<=^):[^\/]+|(?<=\/):[^\/]+)}, '([^\/]|\/\/)+'
+    placeholder_pattern = %r{((?<=^):[^\/]+|(?<=\/):[^\/]+)}
+    anything_but_a_single_slash = '([^\/]|\/\/)+'
+    regexp = template.gsub placeholder_pattern, anything_but_a_single_slash
     url.match "#{regexp}$"
   end
 

--- a/lib/lhc/endpoint.rb
+++ b/lib/lhc/endpoint.rb
@@ -2,7 +2,8 @@
 # The url can also be an url-template.
 class LHC::Endpoint
 
-  PLACEHOLDER = /\:[A-Z,a-z,_,-]+/
+  PLACEHOLDER = %r{(?<=^):[^\/]+|(?<=\/):[^\/]+}
+  ANYTHING_BUT_SINGLE_SLASH = '([^\/]|\/\/)+'.freeze
 
   attr_accessor :url, :options
 
@@ -62,9 +63,7 @@ class LHC::Endpoint
   # Returns true if concrete url is covered by the template
   # Example: :datastore/contracts/:id == http://local.ch/contracts/1
   def self.match?(url, template)
-    placeholder_pattern = %r{((?<=^):[^\/]+|(?<=\/):[^\/]+)}
-    anything_but_a_single_slash = '([^\/]|\/\/)+'
-    regexp = template.gsub placeholder_pattern, anything_but_a_single_slash
+    regexp = template.gsub PLACEHOLDER, ANYTHING_BUT_SINGLE_SLASH
     url.match "#{regexp}$"
   end
 

--- a/lib/lhc/endpoint.rb
+++ b/lib/lhc/endpoint.rb
@@ -60,13 +60,10 @@ class LHC::Endpoint
 
   # Compares a concrete url with a template
   # Returns true if concrete url is covered by the template
+  # Example: :datastore/contracts/:id == http://local.ch/contracts/1
   def self.match?(url, template)
-    regexp = template
-    LHC::Endpoint.placeholders(template).each do |placeholder|
-      regexp = regexp.gsub(placeholder, '.*')
-    end
-    regexp = regexp.gsub('/', '(?<!/)/(?!/)')
-    url.match(Regexp.new("^#{regexp}$"))
+    regexp = template.gsub %r{((?<=^):[^\/]+|(?<=\/):[^\/]+)}, '([^\/]|\/\/)+'
+    url.match "#{regexp}$"
   end
 
   # Returns all placeholders found in the url-template.

--- a/non_rails_spec/request/request_spec.rb
+++ b/non_rails_spec/request/request_spec.rb
@@ -7,7 +7,7 @@ describe LHC::Request do
   end
   context 'request without rails' do
     it 'does have deep_merge dependency met' do
-      expect { described_class.new({}, false) }.to_not raise_error
+      expect { described_class.new({}, false) }.not_to raise_error
     end
   end
 end

--- a/spec/endpoint/match_spec.rb
+++ b/spec/endpoint/match_spec.rb
@@ -7,7 +7,10 @@ describe LHC::Endpoint do
         {
           ':datastore/v2/places' => 'http://local.ch:8082/v2/places',
           ':datastore/v2/places/:id' => 'http://local.ch:8082/v2/places/ZW9OJyrbt4OZE9ueu80w-A',
-          ':datastore/v2/places/:namespace/:id' => 'http://local.ch:8082/v2/places/switzerland/ZW9OJyrbt'
+          ':datastore/v2/places/:namespace/:id' => 'http://local.ch:8082/v2/places/switzerland/ZW9OJyrbt',
+          ':datastore/addresses/:id' => 'http://local.ch/addresses/123',
+          'http://local.ch/addresses/:id' => 'http://local.ch/addresses/123',
+          ':datastore/customers/:id/addresses' => 'http://local.ch:80/server/rest/v1/customers/123/addresses'
         }.each do |template, url|
           expect(
             described_class.match?(url, template)
@@ -20,7 +23,8 @@ describe LHC::Endpoint do
       it 'checks if a url matches a template' do
         {
           ':datastore/v2/places' => 'http://local.ch:8082/v2/places/ZW9OJyrbt4OZE9ueu80w-A',
-          ':datastore/:campaign_id/feedbacks' => 'http://datastore.local.ch/feedbacks'
+          ':datastore/:campaign_id/feedbacks' => 'http://datastore.local.ch/feedbacks',
+          ':datastore/customers/:id' => 'http://local.ch:80/server/rest/v1/customers/123/addresses'
         }.each do |template, url|
           expect(
             described_class.match?(url, template)

--- a/spec/request/error_handling_spec.rb
+++ b/spec/request/error_handling_spec.rb
@@ -49,7 +49,6 @@ describe LHC::Request do
   end
 
   context 'parsing error' do
-    
     before(:each) do
       stub_request(:get, 'http://datastore/v2/feedbacks').to_return(body: 'invalid json')
     end


### PR DESCRIPTION
The endpoint matcher was broken/incomplete

This method is used to check if a certain url matches a certain url template

```
:datastore/v2/places/:id == http://local.ch/v2/places/123
:datastore/v2/places/:id != http://local.ch/v2/places
etc.
```
