### PR TITLE
! fix endpoint detection with dots

### DIFF
--- a/lib/lhc/endpoint.rb
+++ b/lib/lhc/endpoint.rb
@@ -2,8 +2,8 @@
 # The url can also be an url-template.
 class LHC::Endpoint
 
-  PLACEHOLDER = %r{(?<=^):[^\/]+|(?<=\/):[^\/]+}
-  ANYTHING_BUT_SINGLE_SLASH = '([^\/]|\/\/)+'.freeze
+  PLACEHOLDER = %r{(?<=^):[^\/\.]+|(?<=\/):[^\/\.]+}
+  ANYTHING_BUT_SINGLE_SLASH_AND_DOT = '([^\/\.]|\/\/)+'.freeze
 
   attr_accessor :url, :options
 
@@ -63,7 +63,7 @@ class LHC::Endpoint
   # Returns true if concrete url is covered by the template
   # Example: :datastore/contracts/:id == http://local.ch/contracts/1
   def self.match?(url, template)
-    regexp = template.gsub PLACEHOLDER, ANYTHING_BUT_SINGLE_SLASH
+    regexp = template.gsub PLACEHOLDER, ANYTHING_BUT_SINGLE_SLASH_AND_DOT
     url.match "#{regexp}$"
   end
 

--- a/spec/endpoint/compile_spec.rb
+++ b/spec/endpoint/compile_spec.rb
@@ -19,5 +19,12 @@ describe LHC::Endpoint do
         endpoint.compile(find_value)
       ).to eq "http://datastore/v2"
     end
+
+    it 'compiles when templates contain dots' do
+      endpoint = described_class.new(':datastore/entries/:id.json')
+      expect(
+        endpoint.compile(datastore: 'http://datastore', id: 123)
+      ).to eq "http://datastore/entries/123.json"
+    end
   end
 end

--- a/spec/endpoint/match_spec.rb
+++ b/spec/endpoint/match_spec.rb
@@ -10,7 +10,8 @@ describe LHC::Endpoint do
           ':datastore/v2/places/:namespace/:id' => 'http://local.ch:8082/v2/places/switzerland/ZW9OJyrbt',
           ':datastore/addresses/:id' => 'http://local.ch/addresses/123',
           'http://local.ch/addresses/:id' => 'http://local.ch/addresses/123',
-          ':datastore/customers/:id/addresses' => 'http://local.ch:80/server/rest/v1/customers/123/addresses'
+          ':datastore/customers/:id/addresses' => 'http://local.ch:80/server/rest/v1/customers/123/addresses',
+          ':datastore/entries/:id.json' => 'http://local.ch/entries/123.json'
         }.each do |template, url|
           expect(
             described_class.match?(url, template)
@@ -24,7 +25,8 @@ describe LHC::Endpoint do
         {
           ':datastore/v2/places' => 'http://local.ch:8082/v2/places/ZW9OJyrbt4OZE9ueu80w-A',
           ':datastore/:campaign_id/feedbacks' => 'http://datastore.local.ch/feedbacks',
-          ':datastore/customers/:id' => 'http://local.ch:80/server/rest/v1/customers/123/addresses'
+          ':datastore/customers/:id' => 'http://local.ch:80/server/rest/v1/customers/123/addresses',
+          ':datastore/entries/:id' => 'http://local.ch/entries/123.json'
         }.each do |template, url|
           expect(
             described_class.match?(url, template)


### PR DESCRIPTION
Fixes https://github.com/local-ch/lhc/issues/53

Fixes endpoint detection with dots, a regression from the previous regexp optimizations for url-templates.

```ruby
LHC.config.placeholder(:devices, ':datastore/devices/:device_id.json')
LHC.get(:devices, params: { device_id: device_id })
# Compilation incomplete. Unable to find value for device_id.json
```
Now the : (column) indicated variables don't include `dots` anymore.

Also evaluated to switch to the [rfc6570](https://tools.ietf.org/html/rfc6570) but it excludes uri scheme from templating, so stuff like `:datastore/v2/place/:id` would stop working, what I would find quite inconvenient right now.