### PR TITLE
+ improve accessing response data

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ Currently supported formats: `json`
 
 → [Read more about the response object](docs/response.md)
 
+## Accessing data
+
+The response data can be access with dot-notation and square-bracket notation. You can convert response data to open structs or json (if the response format is json).
+
+```ruby
+  response = LHC.request(url: 'http://datastore/entry/1')
+  response.data.as_open_struct #<OpenStruct name='local.ch'>
+  response.data.as_json # { name: 'local.ch' }
+  response.data.name # 'local.ch'
+  response.data[:name] # 'local.ch'
+```
+
 ## Parallel requests
 
 If you pass an array of requests to `LHC.request`, it will perform those requests in parallel.

--- a/lib/lhc/formats/json.rb
+++ b/lib/lhc/formats/json.rb
@@ -9,10 +9,12 @@ class JsonFormat
     super(options)
   end
 
-  def parse(response)
-    JSON.parse(response.body, object_class: OpenStruct)
-  rescue JSON::ParserError => e
-    raise LHC::ParserError.new(e.message, response)
+  def as_json(response)
+    parse(response, Hash)
+  end
+
+  def as_open_struct(response)
+    parse(response, OpenStruct)
   end
 
   def to_s
@@ -21,5 +23,13 @@ class JsonFormat
 
   def to_sym
     to_s.to_sym
+  end
+
+  private
+
+  def parse(response, object_class)
+    JSON.parse(response.body, object_class: object_class)
+  rescue JSON::ParserError => e
+    raise LHC::ParserError.new(e.message, response)
   end
 end

--- a/lib/lhc/response.rb
+++ b/lib/lhc/response.rb
@@ -13,11 +13,8 @@ class LHC::Response
     self.raw = raw
   end
 
-  # Access response data.
-  # Cache parsing.
   def data
-    @data ||= format.parse(self)
-    @data
+    @data ||= LHC::Response::Data.new(self)
   end
 
   def effective_url
@@ -53,13 +50,13 @@ class LHC::Response
     raw.success?
   end
 
-  private
-
-  attr_accessor :raw
-
   def format
     return JsonFormat.new if request.nil?
     request.format
   end
+
+  private
+
+  attr_accessor :raw
 
 end

--- a/lib/lhc/response/data.rb
+++ b/lib/lhc/response/data.rb
@@ -16,7 +16,8 @@ class LHC::Response::Data
   end
 
   def [](key)
-    as_json.with_indifferent_access[key]
+    @hash ||= as_json.with_indifferent_access
+    @hash[key]
   end
 
   private

--- a/lib/lhc/response/data.rb
+++ b/lib/lhc/response/data.rb
@@ -1,0 +1,33 @@
+# Response data is data provided through the response body
+# but made accssible in the ruby world
+class LHC::Response::Data
+
+  def initialize(response)
+    @response = response
+    set_dynamic_accessor_methods
+  end
+
+  def as_json
+    response.format.as_json(response)
+  end
+
+  def as_open_struct
+    response.format.as_open_struct(response)
+  end
+
+  def [](key)
+    as_json.with_indifferent_access[key]
+  end
+
+  private
+
+  attr_reader :response
+
+  def set_dynamic_accessor_methods
+    as_json.keys.each do |key|
+      define_singleton_method key do |*args|
+        as_open_struct.send key, *args
+      end
+    end
+  end
+end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION = "3.7.0.pre-1"
+  VERSION = "3.7.0.1"
 end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION = "3.7.0.1"
+  VERSION = "3.7.0.pre1"
 end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION = "3.6.1"
+  VERSION = "3.7.0.pre-1"
 end

--- a/spec/response/data_spec.rb
+++ b/spec/response/data_spec.rb
@@ -8,9 +8,22 @@ describe LHC::Response do
 
     let(:raw_response) { OpenStruct.new(body: body.to_json) }
 
+    let(:response) { LHC::Response.new(raw_response, nil) }
+
     it 'makes data from response body available' do
-      response = LHC::Response.new(raw_response, nil)
       expect(response.data.some_key.nested).to eq value
+    end
+
+    it 'makes data from response body available with hash bracket notation' do
+      expect(response.data[:some_key][:nested]).to eq value
+    end
+
+    it 'can be converted to json with the as_json method' do
+      expect(response.data.as_json).to eq body.as_json
+    end
+
+    it 'can be converted to an open struct with the as_open_struct method' do
+      expect(response.data.as_open_struct).to eq JSON.parse(response.body, object_class: OpenStruct)
     end
   end
 end


### PR DESCRIPTION
Minor version increase

## Accessing data

The response data can be access with dot-notation and square-bracket notation. You can convert response data to open structs or json (if the response format is json).

```ruby
  response = LHC.request(url: 'http://datastore/entry/1')
  response.data.as_open_struct #<OpenStruct name='local.ch'>
  response.data.as_json # { name: 'local.ch' }
  response.data.name # 'local.ch'
  response.data[:name] # 'local.ch'
```