### PR TITLE
Access data directly on response

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ The response data can be access with dot-notation and square-bracket notation. Y
   response.data[:name] # 'local.ch'
 ```
 
+You can also access response data directly through the response object (with square bracket notation only):
+
+```ruby
+  LHC.json.get(url: 'http://datastore/entry/1')[:name]
+```
+
 ## Parallel requests
 
 If you pass an array of requests to `LHC.request`, it will perform those requests in parallel.

--- a/lib/lhc/response.rb
+++ b/lib/lhc/response.rb
@@ -17,6 +17,10 @@ class LHC::Response
     @data ||= LHC::Response::Data.new(self)
   end
 
+  def [](key)
+    data[key]
+  end
+
   def effective_url
     raw.effective_url
   end

--- a/spec/response/data_accessor_spec.rb
+++ b/spec/response/data_accessor_spec.rb
@@ -1,13 +1,23 @@
 require 'rails_helper'
 
 describe LHC do
-  context 'data accessor' do
-    it 'makes data accessible with square bracket accessor' do
+  context 'data accessor (hash with indifferent access)' do
+
+    before(:each) do
       stub_request(:get, "http://local.ch/")
         .with(headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' })
         .to_return(body: { 'MyProp' => 'MyValue' }.to_json)
+    end
+
+    it 'makes data accessible with square bracket accessor (string)' do
       expect(
         LHC.json.get('http://local.ch')['MyProp']
+      ).to eq 'MyValue'
+    end
+
+    it 'makes data accessible with square bracket accessor (symbol)' do
+      expect(
+        LHC.json.get('http://local.ch')[:MyProp]
       ).to eq 'MyValue'
     end
   end

--- a/spec/response/data_accessor_spec.rb
+++ b/spec/response/data_accessor_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe LHC do
+  context 'data accessor' do
+    it 'makes data accessible with square bracket accessor' do
+      stub_request(:get, "http://local.ch/")
+        .with(headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' })
+        .to_return(body: {'MyProp' => 'MyValue'}.to_json)
+      expect(
+        LHC.json.get('http://local.ch')['MyProp']
+      ).to eq 'MyValue'
+    end
+  end
+end

--- a/spec/response/data_accessor_spec.rb
+++ b/spec/response/data_accessor_spec.rb
@@ -5,7 +5,7 @@ describe LHC do
     it 'makes data accessible with square bracket accessor' do
       stub_request(:get, "http://local.ch/")
         .with(headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' })
-        .to_return(body: {'MyProp' => 'MyValue'}.to_json)
+        .to_return(body: { 'MyProp' => 'MyValue' }.to_json)
       expect(
         LHC.json.get('http://local.ch')['MyProp']
       ).to eq 'MyValue'

--- a/spec/response/data_accessor_spec.rb
+++ b/spec/response/data_accessor_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe LHC do
   context 'data accessor (hash with indifferent access)' do
-
     before(:each) do
       stub_request(:get, "http://local.ch/")
         .with(headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' })


### PR DESCRIPTION
Minor version

You can also access response data directly through the response object (with square bracket notation only):

```ruby
  LHC.json.get(url: 'http://datastore/entry/1')[:name]
```

This makes accessing the data object with `.data` unnecessary and direct data retrieval a little more convenient. 