### PR TITLE
! dont configure rspec when its not arround

### DIFF
--- a/lib/lhc.rb
+++ b/lib/lhc.rb
@@ -17,5 +17,11 @@ end
 Gem.find_files('lhc/**/*.rb')
   .sort
   .each do |path|
-    require path if defined?(Rails) || !File.basename(path).include?('railtie.rb')
+    if (
+        defined?(Rails) ||
+        !File.basename(path).include?('railtie.rb') ||
+        path.match(%r{\/test\/.*_helper})
+    )
+      require path
+    end
   end

--- a/lib/lhc.rb
+++ b/lib/lhc.rb
@@ -17,11 +17,9 @@ end
 Gem.find_files('lhc/**/*.rb')
   .sort
   .each do |path|
-    if (
-        defined?(Rails) ||
+    if  defined?(Rails) ||
         !File.basename(path).include?('railtie.rb') ||
         path.match(%r{\/test\/.*_helper})
-    )
       require path
     end
   end

--- a/lib/lhc.rb
+++ b/lib/lhc.rb
@@ -16,10 +16,9 @@ end
 
 Gem.find_files('lhc/**/*.rb')
   .sort
-  .each do |path|
-    if  defined?(Rails) ||
-        !File.basename(path).include?('railtie.rb') ||
-        path.match(%r{\/test\/.*_helper})
-      require path
-    end
+  .reject do |path|
+    (!defined?(Rails) && File.basename(path).include?('railtie.rb')) || # don't require railtie if Rails is not around
+      path.match(%r{\/test\/.*_helper}) # don't require test helper (as we ask people to explicitly require if needed)
+  end.each do |path|
+    require path
   end

--- a/lib/lhc/test/cache_helper.rb
+++ b/lib/lhc/test/cache_helper.rb
@@ -1,7 +1,9 @@
-RSpec.configure do |config|
-  LHC::Caching.cache = ActiveSupport::Cache::MemoryStore.new
+if defined?(RSpec)
+  RSpec.configure do |config|
+    LHC::Caching.cache = ActiveSupport::Cache::MemoryStore.new
 
-  config.before(:each) do
-    LHC::Caching.cache.clear
+    config.before(:each) do
+      LHC::Caching.cache.clear
+    end
   end
 end

--- a/lib/lhc/test/cache_helper.rb
+++ b/lib/lhc/test/cache_helper.rb
@@ -1,9 +1,7 @@
-if defined?(RSpec)
-  RSpec.configure do |config|
-    LHC::Caching.cache = ActiveSupport::Cache::MemoryStore.new
+RSpec.configure do |config|
+  LHC::Caching.cache = ActiveSupport::Cache::MemoryStore.new
 
-    config.before(:each) do
-      LHC::Caching.cache.clear
-    end
+  config.before(:each) do
+    LHC::Caching.cache.clear
   end
 end


### PR DESCRIPTION
*PATCH* 
Apps in production that dont have rspec gem were raising exceptions because this file was not testing if rspec is arround.