### PR TITLE
[Caching Interceptor] Improve cached methods

### DIFF
--- a/docs/interceptors/caching.md
+++ b/docs/interceptors/caching.md
@@ -13,7 +13,6 @@ You can configure your own cache (default Rails.cache) and logger (default Rails
   LHC::Caching.logger = Logger.new(STDOUT)
 ```
 
-
 Caching is not enabled by default, although you added it to your basic set of interceptors.
 If you want to have requests served/stored and stored in/from cache, you have to enable it by request.
 
@@ -27,6 +26,12 @@ You can also enable caching when configuring an endpoint in LHS.
   class Feedbacks < LHS::Service
     endpoint ':datastore/v2/feedbacks', cache: true
   end
+```
+
+Only GET requests are cached by default. If you want to cache any other request method, just configure it:
+
+```ruby
+  LHC.get('http://local.ch', cache: true, cached_methods: [:post, :head])
 ```
 
 ## Options

--- a/spec/interceptors/caching/main_spec.rb
+++ b/spec/interceptors/caching/main_spec.rb
@@ -28,7 +28,6 @@ describe LHC::Caching do
     expect(original_response.body).to eq cached_response.body
     expect(original_response.code).to eq cached_response.code
     expect(original_response.headers).to eq cached_response.headers
-    expect(original_response.headers).to eq cached_response.headers
     assert_requested stub, times: 1
   end
 

--- a/spec/interceptors/caching/methods_spec.rb
+++ b/spec/interceptors/caching/methods_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe LHC::Caching do
+  before(:each) do
+    LHC.config.interceptors = [LHC::Caching]
+    LHC::Caching.cache = Rails.cache
+    Rails.cache.clear
+  end
+
+  let!(:stub) { stub_request(:post, 'http://local.ch').to_return(status: 200, body: 'The Website') }
+
+  before(:each) do
+    LHC.config.endpoint(:local, 'http://local.ch', cache: true, cache_expires_in: 5.minutes)
+  end
+
+  it 'only caches GET requests by default' do
+    expect(Rails.cache).not_to receive(:write)
+    LHC.post(:local)
+    assert_requested stub, times: 1
+  end
+
+  it 'also caches other methods, when explicitly enabled' do
+    expect(Rails.cache).to receive(:write)
+      .with(
+        "LHC_CACHE(v#{LHC::Caching::CACHE_VERSION}): POST http://local.ch",
+        {
+          body: 'The Website',
+          code: 200,
+          headers: nil,
+          return_code: nil
+        }, { expires_in: 5.minutes }
+      )
+      .and_call_original
+    original_response = LHC.post(:local, cache_methods: [:post])
+    cached_response = LHC.post(:local, cache_methods: [:post])
+    expect(original_response.body).to eq cached_response.body
+    expect(original_response.code).to eq cached_response.code
+    expect(original_response.headers).to eq cached_response.headers
+    expect(original_response.headers).to eq cached_response.headers
+    assert_requested stub, times: 1
+  end
+end

--- a/spec/interceptors/caching/methods_spec.rb
+++ b/spec/interceptors/caching/methods_spec.rb
@@ -36,7 +36,6 @@ describe LHC::Caching do
     expect(original_response.body).to eq cached_response.body
     expect(original_response.code).to eq cached_response.code
     expect(original_response.headers).to eq cached_response.headers
-    expect(original_response.headers).to eq cached_response.headers
     assert_requested stub, times: 1
   end
 end


### PR DESCRIPTION
*Major Version: As finally sets GET as the only HTTP method cached by default, when enabling the caching interceptor*

## Caching Interceptor

[...]

Only GET requests are cached by default. If you want to cache any other request method, just configure it:

```ruby
  LHC.get('http://local.ch', cache: true, cached_methods: [:post, :head])
```