### PR TITLE
Add mock to cached response data

### DIFF
--- a/lib/lhc/interceptors/caching.rb
+++ b/lib/lhc/interceptors/caching.rb
@@ -46,6 +46,8 @@ class LHC::Caching < LHC::Interceptor
     data[:headers] = response.headers ? Hash[response.headers] : response.headers
     # return_code is quite important as Typhoeus relies on it in order to determin 'success?'
     data[:return_code] = response.options[:return_code]
+    # in a test scenario typhoeus uses mocks and not return_code to determine 'success?'
+    data[:mock] = response.mock
     data
   end
 

--- a/lib/lhc/response.rb
+++ b/lib/lhc/response.rb
@@ -41,6 +41,10 @@ class LHC::Response
     raw.options
   end
 
+  def mock
+    raw.mock
+  end
+
   # Provides response time in ms.
   def time
     (raw.time || 0) * 1000

--- a/spec/interceptors/caching/main_spec.rb
+++ b/spec/interceptors/caching/main_spec.rb
@@ -19,7 +19,8 @@ describe LHC::Caching do
           body: 'The Website',
           code: 200,
           headers: nil,
-          return_code: nil
+          return_code: nil,
+          mock: :webmock
         }, { expires_in: 5.minutes }
       )
       .and_call_original
@@ -28,6 +29,8 @@ describe LHC::Caching do
     expect(original_response.body).to eq cached_response.body
     expect(original_response.code).to eq cached_response.code
     expect(original_response.headers).to eq cached_response.headers
+    expect(original_response.options[:return_code]).to eq cached_response.options[:return_code]
+    expect(original_response.mock).to eq cached_response.mock
     assert_requested stub, times: 1
   end
 

--- a/spec/interceptors/caching/methods_spec.rb
+++ b/spec/interceptors/caching/methods_spec.rb
@@ -27,7 +27,8 @@ describe LHC::Caching do
           body: 'The Website',
           code: 200,
           headers: nil,
-          return_code: nil
+          return_code: nil,
+          mock: :webmock
         }, { expires_in: 5.minutes }
       )
       .and_call_original


### PR DESCRIPTION
*PATCH*

Because typhoeus relies on `mock` internal when determining `success?` https://github.com/typhoeus/typhoeus/blob/181834e2483d392d0f7ab0cd17f544cd252c7b2f/lib/typhoeus/response/status.rb#L49 I was faced with some failing responses served from cache.

Adding mock to the data stored and restored from cache, solved that problem.