### PR TITLE
[FIX] Dont do requests when done with hydra but served from cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ Gemfile.lock
 /vendor/assets/bower_components
 *.bowerrc
 bower.json
+
+spec/dummy/tmp/cache

--- a/lib/lhc/concerns/lhc/basic_methods.rb
+++ b/lib/lhc/concerns/lhc/basic_methods.rb
@@ -30,7 +30,7 @@ module LHC
         options.each do |option|
           request = LHC::Request.new(option, false)
           requests << request
-          hydra.queue request.raw
+          hydra.queue request.raw unless request.response.present?
         end
         hydra.run
         requests.map(&:response)

--- a/spec/interceptors/caching/hydra_spec.rb
+++ b/spec/interceptors/caching/hydra_spec.rb
@@ -16,8 +16,8 @@ describe LHC::Caching do
   end
 
   it 'does not fetch requests served from cache when doing requests in parallel with hydra' do
-    LHC.request([{url: 'http://local.ch', cache: true}, {url: 'http://local.ch/weather', cache: true}])
-    LHC.request([{url: 'http://local.ch', cache: true}, {url: 'http://local.ch/weather', cache: true}])
+    LHC.request([{ url: 'http://local.ch', cache: true }, { url: 'http://local.ch/weather', cache: true }])
+    LHC.request([{ url: 'http://local.ch', cache: true }, { url: 'http://local.ch/weather', cache: true }])
     assert_requested first_request, times: 1
     assert_requested second_request, times: 1
   end

--- a/spec/interceptors/caching/hydra_spec.rb
+++ b/spec/interceptors/caching/hydra_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe LHC::Caching do
+  before(:each) do
+    LHC.config.interceptors = [LHC::Caching]
+    LHC::Caching.cache = Rails.cache
+    Rails.cache.clear
+  end
+
+  let!(:first_request) do
+    stub_request(:get, "http://local.ch/").to_return(body: 'Website')
+  end
+
+  let!(:second_request) do
+    stub_request(:get, "http://local.ch/weather").to_return(body: 'The weather')
+  end
+
+  it 'does not fetch requests served from cache when doing requests in parallel with hydra' do
+    LHC.request([{url: 'http://local.ch', cache: true}, {url: 'http://local.ch/weather', cache: true}])
+    LHC.request([{url: 'http://local.ch', cache: true}, {url: 'http://local.ch/weather', cache: true}])
+    assert_requested first_request, times: 1
+    assert_requested second_request, times: 1
+  end
+end


### PR DESCRIPTION
*PATCH*

Requests served from cache have been performed nevertheless when done in parallel with hydra.