### PR TITLE
! consider url params when matching url templates

### DIFF
--- a/lib/lhc/endpoint.rb
+++ b/lib/lhc/endpoint.rb
@@ -5,6 +5,7 @@ class LHC::Endpoint
 
   PLACEHOLDER ||= %r{:[^\/\.:;\d\&]+}
   ANYTHING_BUT_SINGLE_SLASH_AND_DOT ||= '([^\/\.]|\/\/)+'.freeze
+  URL_PARAMETERS ||= '(\\?.*)*'
 
   attr_accessor :url, :options
 
@@ -65,6 +66,7 @@ class LHC::Endpoint
   # Example: :datastore/contracts/:id == http://local.ch/contracts/1
   def self.match?(url, template)
     regexp = template.gsub PLACEHOLDER, ANYTHING_BUT_SINGLE_SLASH_AND_DOT
+    regexp = regexp + URL_PARAMETERS
     url.match "#{regexp}$"
   end
 
@@ -83,6 +85,7 @@ class LHC::Endpoint
       name = placeholder.gsub(":", '')
       regexp = regexp.gsub(placeholder, "(?<#{name}>.*)")
     end
+    regexp = regexp + URL_PARAMETERS
     matchdata = url.match(Regexp.new("^#{regexp}$"))
     LHC::Endpoint.placeholders(template).each do |placeholder|
       name = placeholder.gsub(':', '')

--- a/lib/lhc/endpoint.rb
+++ b/lib/lhc/endpoint.rb
@@ -66,7 +66,7 @@ class LHC::Endpoint
   # Example: :datastore/contracts/:id == http://local.ch/contracts/1
   def self.match?(url, template)
     regexp = template.gsub PLACEHOLDER, ANYTHING_BUT_SINGLE_SLASH_AND_DOT
-    regexp = regexp + URL_PARAMETERS
+    regexp += URL_PARAMETERS
     url.match "#{regexp}$"
   end
 
@@ -85,7 +85,7 @@ class LHC::Endpoint
       name = placeholder.gsub(":", '')
       regexp = regexp.gsub(placeholder, "(?<#{name}>.*)")
     end
-    regexp = regexp + URL_PARAMETERS
+    regexp += URL_PARAMETERS
     matchdata = url.match(Regexp.new("^#{regexp}$"))
     LHC::Endpoint.placeholders(template).each do |placeholder|
       name = placeholder.gsub(':', '')

--- a/spec/endpoint/match_spec.rb
+++ b/spec/endpoint/match_spec.rb
@@ -11,7 +11,8 @@ describe LHC::Endpoint do
           ':datastore/addresses/:id' => 'http://local.ch/addresses/123',
           'http://local.ch/addresses/:id' => 'http://local.ch/addresses/123',
           ':datastore/customers/:id/addresses' => 'http://local.ch:80/server/rest/v1/customers/123/addresses',
-          ':datastore/entries/:id.json' => 'http://local.ch/entries/123.json'
+          ':datastore/entries/:id.json' => 'http://local.ch/entries/123.json',
+          ':datastore/places/:place_id/feedbacks' => 'http://local.ch/places/1/feedbacks?limit=10&offset=0'
         }.each do |template, url|
           expect(
             LHC::Endpoint.match?(url, template)


### PR DESCRIPTION
*Patch Version*

Some hyperlinks already contain get parameters, reflecting default parameter/values, for example offset & limit:

```
GET http://datastore/places/1
{
  feedbacks: { href: 'http://datastore/places/1/feedbacks?limit=10&offset=0' }
}
```

Those have not been matched by url templates like `:datastore/places/:id/feedbacks`.

Now they are.