### PR TITLE
! fix delegate by requiring active support ext explicit

### DIFF
--- a/lib/lhc/response.rb
+++ b/lib/lhc/response.rb
@@ -1,4 +1,5 @@
 require 'typhoeus'
+require 'active_support/core_ext/module'
 
 # The response contains the raw response (typhoeus)
 # and provides functionality to access response data.


### PR DESCRIPTION
*PATCH*

LHC version 5.1.0 broke latest LHS and I don't know for which reasons. Maybe an implicit patch/minor version upgrade of `active_support` triggered that:

```
`<class:Response>': undefined method `delegate' for LHC::Response:Class (NoMethodError) Did you mean? DelegateClass
```