### PR TITLE
Mark responses served from from cache as from cache

### DIFF
--- a/lib/lhc/interceptors/caching.rb
+++ b/lib/lhc/interceptors/caching.rb
@@ -34,7 +34,7 @@ class LHC::Caching < LHC::Interceptor
   # converts json we read from the cache to an LHC::Response object
   def from_cache(request, data)
     raw = Typhoeus::Response.new(data)
-    response = LHC::Response.new(raw, request, true)
+    response = LHC::Response.new(raw, request, from_cache: true)
     request.response = response
     response
   end

--- a/lib/lhc/interceptors/caching.rb
+++ b/lib/lhc/interceptors/caching.rb
@@ -34,7 +34,9 @@ class LHC::Caching < LHC::Interceptor
   # converts json we read from the cache to an LHC::Response object
   def from_cache(request, data)
     raw = Typhoeus::Response.new(data)
-    request.response = LHC::Response.new(raw, request)
+    response = LHC::Response.new(raw, request, true)
+    request.response = response
+    response
   end
 
   # converts a LHC::Response object to json, we store in the cache

--- a/lib/lhc/response.rb
+++ b/lib/lhc/response.rb
@@ -6,13 +6,13 @@ require 'active_support/core_ext/module'
 class LHC::Response
   autoload :Data, 'lhc/response/data'
 
-  attr_accessor :request, :body_replacement, :from_cache
+  attr_accessor :request, :body_replacement
 
   delegate :effective_url, :code, :headers, :options, :mock, :success?, to: :raw
 
   # A response is initalized with the underlying raw response (typhoeus in our case)
   # and the associated request.
-  def initialize(raw, request, from_cache = false)
+  def initialize(raw, request, from_cache: false)
     self.request = request
     self.raw = raw
     @from_cache = from_cache
@@ -24,6 +24,10 @@ class LHC::Response
 
   def [](key)
     data[key]
+  end
+
+  def from_cache?
+    @from_cache
   end
 
   def body

--- a/lib/lhc/response.rb
+++ b/lib/lhc/response.rb
@@ -7,8 +7,10 @@ class LHC::Response
   autoload :Data, 'lhc/response/data'
 
   attr_accessor :request, :body_replacement
+  attr_reader :from_cache
 
   delegate :effective_url, :code, :headers, :options, :mock, :success?, to: :raw
+  alias from_cache? from_cache
 
   # A response is initalized with the underlying raw response (typhoeus in our case)
   # and the associated request.
@@ -24,10 +26,6 @@ class LHC::Response
 
   def [](key)
     data[key]
-  end
-
-  def from_cache?
-    @from_cache
   end
 
   def body

--- a/lib/lhc/response.rb
+++ b/lib/lhc/response.rb
@@ -12,9 +12,10 @@ class LHC::Response
 
   # A response is initalized with the underlying raw response (typhoeus in our case)
   # and the associated request.
-  def initialize(raw, request)
+  def initialize(raw, request, from_cache = false)
     self.request = request
     self.raw = raw
+    self.from_cache = from_cache
   end
 
   def data
@@ -45,6 +46,6 @@ class LHC::Response
 
   private
 
-  attr_accessor :raw
+  attr_accessor :raw, :from_cache
 
 end

--- a/lib/lhc/response.rb
+++ b/lib/lhc/response.rb
@@ -6,7 +6,7 @@ require 'active_support/core_ext/module'
 class LHC::Response
   autoload :Data, 'lhc/response/data'
 
-  attr_accessor :request, :body_replacement
+  attr_accessor :request, :body_replacement, :from_cache
 
   delegate :effective_url, :code, :headers, :options, :mock, :success?, to: :raw
 
@@ -15,7 +15,7 @@ class LHC::Response
   def initialize(raw, request, from_cache = false)
     self.request = request
     self.raw = raw
-    self.from_cache = from_cache
+    @from_cache = from_cache
   end
 
   def data
@@ -46,6 +46,6 @@ class LHC::Response
 
   private
 
-  attr_accessor :raw, :from_cache
+  attr_accessor :raw
 
 end

--- a/spec/interceptors/caching/main_spec.rb
+++ b/spec/interceptors/caching/main_spec.rb
@@ -59,4 +59,13 @@ describe LHC::Caching do
     expect(Rails.cache).to receive(:write).once
     LHC.get(:local)
   end
+
+ 
+  it 'marks response not from cache as not served from cache and from cache as served from cache' do
+    stub
+    LHC.config.endpoint(:local, 'http://local.ch', cache: true, cache_expires_in: 5.minutes)
+    original_response = LHC.get(:local)
+    cached_response = LHC.get(:local)
+    binding.pry
+  end
 end

--- a/spec/interceptors/caching/main_spec.rb
+++ b/spec/interceptors/caching/main_spec.rb
@@ -65,7 +65,7 @@ describe LHC::Caching do
     LHC.config.endpoint(:local, 'http://local.ch', cache: true, cache_expires_in: 5.minutes)
     original_response = LHC.get(:local)
     cached_response = LHC.get(:local)
-    expect(original_response.from_cache).to eq false
-    expect(cached_response.from_cache).to eq true
+    expect(original_response.from_cache?).to eq false
+    expect(cached_response.from_cache?).to eq true
   end
 end

--- a/spec/interceptors/caching/main_spec.rb
+++ b/spec/interceptors/caching/main_spec.rb
@@ -60,12 +60,12 @@ describe LHC::Caching do
     LHC.get(:local)
   end
 
- 
   it 'marks response not from cache as not served from cache and from cache as served from cache' do
     stub
     LHC.config.endpoint(:local, 'http://local.ch', cache: true, cache_expires_in: 5.minutes)
     original_response = LHC.get(:local)
     cached_response = LHC.get(:local)
-    binding.pry
+    expect(original_response.from_cache).to eq false
+    expect(cached_response.from_cache).to eq true
   end
 end


### PR DESCRIPTION
*Minor*

Fixes https://github.com/local-ch/lhc/issues/86

> When using the monitoring interceptor on an LHC instance that also uses the Caching interceptor you may get a skewed picture, because the monitoring interceptor has no way of knowing whether the request was served by the cache or not.