### PR TITLE
Fix basic auth in url

### DIFF
--- a/lib/lhc/endpoint.rb
+++ b/lib/lhc/endpoint.rb
@@ -3,7 +3,7 @@
 # The url can also be an url-template.
 class LHC::Endpoint
 
-  PLACEHOLDER ||= %r{:[^\/\.:;\d\&]+}
+  PLACEHOLDER ||= %r{:[^\/\.:;\d\&@]+}
   ANYTHING_BUT_SINGLE_SLASH_AND_DOT ||= '([^\/\.]|\/\/)+'.freeze
   URL_PARAMETERS ||= '(\\?.*)*'
 

--- a/spec/endpoint/placeholders_spec.rb
+++ b/spec/endpoint/placeholders_spec.rb
@@ -8,5 +8,13 @@ describe LHC::Endpoint do
         endpoint.placeholders
       ).to eq [':campaign_id', ':datastore']
     end
+
+    it 'allows basic auth token in url, like used on github' do
+      stub_request(:get, "https://d123token:@api.github.com/search")
+        .to_return(body: {}.to_json)
+      expect(->{
+        LHC.get("https://d123token:@api.github.com/search")
+      }).not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
*PATCH*


### Problem
LHC failed parsing urls like `https://d123token:@api.github.com/search`. 
As you would find them when communicating with Github Api.
LHC tried to find the `:@api` placeholder in this case.

### Fix
Ignore `@` when it comes to detect placeholders.