### PR TITLE
FIX urls with basic auth

### DIFF
--- a/lib/lhc/endpoint.rb
+++ b/lib/lhc/endpoint.rb
@@ -14,16 +14,44 @@ class LHC::Endpoint
     self.options = options
   end
 
+  def uri
+    @uri ||= parse_url_gracefully(url)
+  end
+
+  def parse_url_gracefully(url)
+    URI.parse(url)
+  rescue Addressable::URI::InvalidURIError
+    url
+  rescue URI::InvalidURIError
+    url
+  end
+
   def compile(params)
-    url.gsub(PLACEHOLDER) do |match|
-      replacement =
-        if params.is_a? Proc
-          params.call(match)
-        else
-          find_value(match, params)
-        end
-      replacement || fail("Compilation incomplete. Unable to find value for #{match.gsub(':', '')}.")
-    end
+    add_basic_auth(
+      without_basic_auth(url).gsub(PLACEHOLDER) do |match|
+        replacement =
+          if params.is_a? Proc
+            params.call(match)
+          else
+            find_value(match, params)
+          end
+        replacement || fail("Compilation incomplete. Unable to find value for #{match.gsub(':', '')}.")
+      end
+    )
+  end
+
+  def add_basic_auth(url)
+    return url if !uri || !uri.is_a?(URI) || (uri.user.blank? && uri.password.blank?)
+    new_uri = parse_url_gracefully(url)
+    new_uri.user = uri.user
+    new_uri.password = uri.password
+    new_uri.to_s
+  end
+
+  # Strips basic auth from the url
+  def without_basic_auth(url)
+    return url if !uri || !uri.is_a?(URI) || (uri.user.blank? && uri.password.blank?)
+    url.gsub("#{uri.user}:#{uri.password}@", '')
   end
 
   # Endpoint options are immutable

--- a/lib/lhc/endpoint.rb
+++ b/lib/lhc/endpoint.rb
@@ -20,8 +20,6 @@ class LHC::Endpoint
 
   def parse_url_gracefully(url)
     URI.parse(url)
-  rescue Addressable::URI::InvalidURIError
-    url
   rescue URI::InvalidURIError
     url
   end

--- a/spec/endpoint/placeholders_spec.rb
+++ b/spec/endpoint/placeholders_spec.rb
@@ -16,5 +16,13 @@ describe LHC::Endpoint do
         LHC.get("https://d123token:@api.github.com/search")
       }).not_to raise_error
     end
+
+    it 'allows complete basic auth (username password) in url, like used for the gemserer' do
+      stub_request(:get, "https://name:password@gemserver.com")
+        .to_return(body: {}.to_json)
+      LHC.get("https://name:password@gemserver.com")
+      # expect(->{
+      # }).not_to raise_error
+    end
   end
 end

--- a/spec/endpoint/placeholders_spec.rb
+++ b/spec/endpoint/placeholders_spec.rb
@@ -20,9 +20,9 @@ describe LHC::Endpoint do
     it 'allows complete basic auth (username password) in url, like used for the gemserer' do
       stub_request(:get, "https://name:password@gemserver.com")
         .to_return(body: {}.to_json)
-      LHC.get("https://name:password@gemserver.com")
-      # expect(->{
-      # }).not_to raise_error
+      expect(->{
+        LHC.get("https://name:password@gemserver.com")
+      }).not_to raise_error
     end
   end
 end


### PR DESCRIPTION
_PATCH_

LHC was not compiling urls when they contained complete basic auth informations `user:password@`.

Now it does, by stripping the auth infos from the url string when compiling, and adding them after compilation happened.