### PR TITLE
Clean filestore

### DIFF
--- a/docs/interceptors/caching.md
+++ b/docs/interceptors/caching.md
@@ -37,7 +37,7 @@ Only GET requests are cached by default. If you want to cache any other request 
 ## Options
 
 ```ruby
-  LHC.get('http://local.ch', cache: true, cache_expires_in: 1.day, cache_race_condition_ttl: 15.seconds)
+  LHC.get('http://local.ch', cache: true, cache_expires_in: 1.day, cache_race_condition_ttl: 15.seconds, preemptively_clean_filestore: true)
 ```
 
 `cache_expires_in` - lets the cache expires every X seconds.
@@ -47,6 +47,9 @@ Only GET requests are cached by default. If you want to cache any other request 
 `cache_race_condition_ttl` - very useful in situations where a cache entry is used very frequently and is under heavy load.
 If a cache expires and due to heavy load several different processes will try to read data natively and then they all will try to write to cache.
 To avoid that case the first process to find an expired cache entry will bump the cache expiration time by the value set in `cache_race_condition_ttl`.
+
+`preemptively_clean_filestore` -  setting this option will prompt deletion of expired cache entries, if the cache backend is `ActiveSupport::Cache::FileStore`. This is useful
+for very shortlived caches, such as LHS' [Request Cycle Cache](https://github.com/local-ch/lhs#request-cycle-cache)
 
 ## Testing
 

--- a/lib/lhc/interceptors/caching.rb
+++ b/lib/lhc/interceptors/caching.rb
@@ -14,6 +14,7 @@ class LHC::Caching < LHC::Interceptor
   def before_request(request)
     return unless cache
     return unless request.options[:cache]
+    cleanup_cache if request.options[:preemptively_clean_filestore]
     return unless cached_method?(request.method, request.options[:cache_methods])
     cached_response_data = cache.fetch(key(request))
     return unless cached_response_data
@@ -30,6 +31,11 @@ class LHC::Caching < LHC::Interceptor
   end
 
   private
+
+  def cleanup_cache
+    return unless cache.is_a?(ActiveSupport::Cache::FileStore)
+    cache.cleanup
+  end
 
   # converts json we read from the cache to an LHC::Response object
   def from_cache(request, data)

--- a/lib/lhc/interceptors/caching.rb
+++ b/lib/lhc/interceptors/caching.rb
@@ -59,7 +59,7 @@ class LHC::Caching < LHC::Interceptor
       key = "#{request.method.upcase} #{request.url}"
       key += "?#{request.params.to_query}" unless request.params.blank?
     end
-    "LHC_CACHE(v#{CACHE_VERSION}): #{key}"
+    "LHC_CACHE(v#{CACHE_VERSION}): #{key}".parameterize
   end
 
   # Checks if the provided method should be cached

--- a/spec/interceptors/caching/main_spec.rb
+++ b/spec/interceptors/caching/main_spec.rb
@@ -14,7 +14,7 @@ describe LHC::Caching do
     LHC.config.endpoint(:local, 'http://local.ch', cache: true, cache_expires_in: 5.minutes)
     expect(Rails.cache).to receive(:write)
       .with(
-        "LHC_CACHE(v#{LHC::Caching::CACHE_VERSION}): GET http://local.ch",
+        "lhc_cache-v1-get-http-local-ch",
         {
           body: 'The Website',
           code: 200,
@@ -45,8 +45,9 @@ describe LHC::Caching do
 
   it 'lets you configure the cache key that will be used' do
     LHC.config.endpoint(:local, 'http://local.ch', cache: true, cache_key: 'STATICKEY')
-    expect(Rails.cache).to receive(:fetch).with("LHC_CACHE(v#{LHC::Caching::CACHE_VERSION}): STATICKEY").and_call_original
-    expect(Rails.cache).to receive(:write).with("LHC_CACHE(v#{LHC::Caching::CACHE_VERSION}): STATICKEY", anything, anything).and_call_original
+    expected_key = "lhc_cache-v1-statickey"
+    expect(Rails.cache).to receive(:fetch).with(expected_key).and_call_original
+    expect(Rails.cache).to receive(:write).with(expected_key, anything, anything).and_call_original
     stub
     LHC.get(:local)
   end

--- a/spec/interceptors/caching/main_spec.rb
+++ b/spec/interceptors/caching/main_spec.rb
@@ -69,4 +69,12 @@ describe LHC::Caching do
     expect(original_response.from_cache?).to eq false
     expect(cached_response.from_cache?).to eq true
   end
+
+  it 'cleans up expired entries' do
+    LHC.config.endpoint(:local, 'http://local.ch', cache: true, cache_key: 'STATICKEY', preemptively_clean_filestore: true)
+    expect(Rails.cache).to receive(:is_a?).with(ActiveSupport::Cache::FileStore).and_return(true)
+    expect(Rails.cache).to receive(:cleanup)
+    stub
+    LHC.get(:local)
+  end
 end

--- a/spec/interceptors/caching/methods_spec.rb
+++ b/spec/interceptors/caching/methods_spec.rb
@@ -22,7 +22,7 @@ describe LHC::Caching do
   it 'also caches other methods, when explicitly enabled' do
     expect(Rails.cache).to receive(:write)
       .with(
-        "LHC_CACHE(v#{LHC::Caching::CACHE_VERSION}): POST http://local.ch",
+        "lhc_cache-v1-post-http-local-ch",
         {
           body: 'The Website',
           code: 200,


### PR DESCRIPTION
https://jira.localsearch.ch/browse/WEB-4155

Call `cache.cleanup` if `preemptively_clean_filestore: true` is set and the cache-backend is a `ActiveSupport::Cache::FileStore`

see: https://github.com/local-ch/lhs/pull/238