### PR TITLE
Ignore certain errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,12 +156,12 @@ response.data.name # 'unknown'
 ### Ignore certain errors
 
 As it's discouraged to rescue errors and then don't handle them (ruby styleguide),
-but you often want to continue working with `nil`, LHC provides the `ignore_errors` option.
+but you often want to continue working with `nil`, LHC provides the `ignored_errors` option.
 
 Errors listed in this option will not be raised and will leave the `response.body` and `response.data` to stay `nil`.
 
 ```ruby
-response = LHC.get('http://something', ignore_errors: [LHC::NotFound])
+response = LHC.get('http://something', ignored_errors: [LHC::NotFound])
 
 response.body # nil
 response.data # nil

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Anything but a response code indicating success (2**) throws an exception.
 
 → [Read more about exceptions](docs/exceptions.md)
 
-## Custom error handling
+### Custom error handling
 
 You can provide custom error handlers to handle errors happening during the request.
 
@@ -151,6 +151,20 @@ If your error handler returns anything else but `nil` it replaces the response b
 handler = ->{ do_something; return {name: 'unknown'} }
 response = LHC.get('http://something', error_handler: handler)
 response.data.name # 'unknown'
+```
+
+### Ignore certain errors
+
+As it's discouraged to rescue errors and then don't handle them (ruby styleguide),
+but you often want to continue working with `nil`, LHC provides the `ignore_errors` option.
+
+Errors listed in this option will not be raised and will leave the `response.body` and `response.data` to stay `nil`.
+
+```ruby
+response = LHC.get('http://something', ignore_errors: [LHC::NotFound])
+
+response.body # nil
+response.data # nil
 ```
 
 ## Interceptors

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -11,7 +11,7 @@ class LHC::Request
   attr_accessor :response, :options, :raw, :format, :error_handler, :errors_ignored
 
   def initialize(options, self_executing = true)
-    self.errors_ignored = options.fetch(:ignore_errors, [])
+    self.errors_ignored = options.fetch(:ignored_errors, [])
     self.options = options.deep_dup || {}
     self.error_handler = options.delete :error_handler
     use_configured_endpoint!

--- a/lib/lhc/response.rb
+++ b/lib/lhc/response.rb
@@ -20,7 +20,7 @@ class LHC::Response
   end
 
   def data
-    @data ||= LHC::Response::Data.new(self)
+    @data ||= body.present? ? LHC::Response::Data.new(self) : nil
   end
 
   def [](key)
@@ -28,7 +28,7 @@ class LHC::Response
   end
 
   def body
-    body_replacement || raw.body
+    body_replacement || raw.body.presence
   end
 
   # Provides response time in ms.

--- a/spec/request/ignore_errors_spec.rb
+++ b/spec/request/ignore_errors_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe LHC::Request do
+  context 'ignore errors' do
+    it 'raises errors for anything but 2XX response codes' do
+      stub_request(:get, 'http://local.ch').to_return(status: 404)
+      response = LHC.get('http://local.ch', ignore_errors: [LHC::NotFound])
+      expect(response.body).to eq nil
+      expect(response.data).to eq nil
+      expect(response.success?).to eq false
+    end
+  end
+end

--- a/spec/request/ignore_errors_spec.rb
+++ b/spec/request/ignore_errors_spec.rb
@@ -4,7 +4,7 @@ describe LHC::Request do
   context 'ignore errors' do
     it 'raises errors for anything but 2XX response codes' do
       stub_request(:get, 'http://local.ch').to_return(status: 404)
-      response = LHC.get('http://local.ch', ignore_errors: [LHC::NotFound])
+      response = LHC.get('http://local.ch', ignored_errors: [LHC::NotFound])
       expect(response.body).to eq nil
       expect(response.data).to eq nil
       expect(response.success?).to eq false


### PR DESCRIPTION
_MINOR_

### Ignore certain errors

As it's discouraged to rescue errors and then don't handle them (ruby styleguide),
but you often want to continue working with `nil`, LHC provides the `ignore_errors` option.

Errors listed in this option will not be raised and will leave the `response.body` and `response.data` to stay `nil`.

```ruby
response = LHC.get('http://something', ignored_errors: [LHC::NotFound])

response.body # nil
response.data # nil
```