### PR TITLE
Take in considarition error inheritance

### DIFF
--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -108,7 +108,7 @@ class LHC::Request
   end
 
   def ignore_error?
-    (errors_ignored || []).detect do |ignored_error|
+    errors_ignored.detect do |ignored_error|
       error <= ignored_error
     end.present?
   end

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -102,9 +102,15 @@ class LHC::Request
   end
 
   def handle_error(response)
-    return if errors_ignored.include?(error)
+    return if ignore_error?
     throw_error(response) unless error_handler
     response.body_replacement = error_handler.call(response)
+  end
+
+  def ignore_error?
+    (errors_ignored || []).detect do |ignored_error|
+      error <= ignored_error
+    end.present?
   end
 
   def error

--- a/spec/request/ignore_errors_spec.rb
+++ b/spec/request/ignore_errors_spec.rb
@@ -24,11 +24,18 @@ describe LHC::Request do
   end
 
   context 'inheritance when ignoring errors' do
-    subject { LHC.get('http://local.ch', ignored_errors: [LHC::Error]) }
     before { stub_request(:get, 'http://local.ch').to_return(status: 404) }
 
-    it 'does not raise an error when its a subclass of the ignored error' do
-      expect { subject }.not_to raise_error
+    it "does not raise an error when it's a subclass of the ignored error" do
+      expect {
+        LHC.get('http://local.ch', ignored_errors: [LHC::Error])
+      }.not_to raise_error
+    end
+
+    it "does raise an error if it's not a subclass of the ignored error" do
+      expect {
+        LHC.get('http://local.ch', ignored_errors: [ArgumentError])
+      }.to raise_error(LHC::NotFound)
     end
   end
 end

--- a/spec/request/ignore_errors_spec.rb
+++ b/spec/request/ignore_errors_spec.rb
@@ -22,4 +22,13 @@ describe LHC::Request do
       expect { subject }.to raise_error LHC::InternalServerError
     end
   end
+
+  context 'inheritance when ignoring errors' do
+    subject { LHC.get('http://local.ch', ignored_errors: [LHC::Error]) }
+    before { stub_request(:get, 'http://local.ch').to_return(status: 404) }
+
+    it 'does not raise an error when its a subclass of the ignored error' do
+      expect { subject }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
_PATCH_

LHC `ignored_errors` has not been taken in consideration inheritance of errors.

## Before

```ruby
LHC.get('http://local.ch', ignored_errors: [LHC::Error])
# returned 404
# has been raising
```

## Now
```ruby
# not raising anymore
```