### PR TITLE
Make ignore errors available

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ response = LHC.get('http://something', ignored_errors: [LHC::NotFound])
 
 response.body # nil
 response.data # nil
+response.error_ignored? # true
+response.request.error_ignored? # true
 ```
 
 ## Interceptors

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -39,6 +39,10 @@ class LHC::Request
     raw.options.fetch(:params, nil) || raw.options[:params] = {}
   end
 
+  def error_ignored?
+    ignore_error?
+  end
+
   private
 
   attr_accessor :iprocessor
@@ -108,9 +112,11 @@ class LHC::Request
   end
 
   def ignore_error?
-    errors_ignored.detect do |ignored_error|
-      error <= ignored_error
-    end.present?
+    @ignore_error ||= begin
+      errors_ignored.detect do |ignored_error|
+        error <= ignored_error
+      end.present?
+    end
   end
 
   def error

--- a/lib/lhc/response.rb
+++ b/lib/lhc/response.rb
@@ -9,6 +9,7 @@ class LHC::Response
   attr_reader :from_cache
 
   delegate :effective_url, :code, :headers, :options, :mock, :success?, to: :raw
+  delegate :error_ignored?, to: :request
   alias from_cache? from_cache
 
   # A response is initalized with the underlying raw response (typhoeus in our case)

--- a/spec/request/ignore_errors_spec.rb
+++ b/spec/request/ignore_errors_spec.rb
@@ -2,24 +2,29 @@ require 'rails_helper'
 
 describe LHC::Request do
   context 'ignoring LHC::NotFound' do
-    subject { LHC.get('http://local.ch', ignored_errors: [LHC::NotFound]) }
+    let(:response) { LHC.get('http://local.ch', ignored_errors: [LHC::NotFound]) }
     before { stub_request(:get, 'http://local.ch').to_return(status: 404) }
 
     it 'does not raise an error' do
-      expect { subject }.not_to raise_error
+      expect { response }.not_to raise_error
     end
 
     it 'body is nil' do
-      expect(subject.body).to eq nil
+      expect(response.body).to eq nil
     end
 
     it 'data is nil' do
-      expect(subject.data).to eq nil
+      expect(response.data).to eq nil
     end
 
     it 'does raise an error for 500' do
       stub_request(:get, 'http://local.ch').to_return(status: 500)
-      expect { subject }.to raise_error LHC::InternalServerError
+      expect { response }.to raise_error LHC::InternalServerError
+    end
+
+    it 'provides the information if the error was ignored' do
+      expect(response.error_ignored?).to eq true
+      expect(response.request.error_ignored?).to eq true
     end
   end
 


### PR DESCRIPTION
_MINOR_

Makes `error_ignored?` available on response and request.

### Ignore certain errors

As it's discouraged to rescue errors and then don't handle them (ruby styleguide),
but you often want to continue working with `nil`, LHC provides the `ignored_errors` option.

Errors listed in this option will not be raised and will leave the `response.body` and `response.data` to stay `nil`.

```ruby
response = LHC.get('http://something', ignored_errors: [LHC::NotFound])

response.body # nil
response.data # nil
response.error_ignored? # true
response.request.error_ignored? # true
```