### PR TITLE
Prometheus interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,12 @@ To monitor and manipulate the http communication done with LHC, you can define i
 → [Read more about interceptors](docs/interceptors.md)
 
 A set of core interceptors is part of LHC,
-like [Caching](/docs/interceptors/caching.md), [Monitoring](/docs/interceptors/monitoring.md), [Authentication](/docs/interceptors/authentication.md), [Rollbar](/docs/interceptors/rollbar.md).
+like 
+[Caching](/docs/interceptors/caching.md),
+[Monitoring](/docs/interceptors/monitoring.md),
+[Authentication](/docs/interceptors/authentication.md),
+[Rollbar](/docs/interceptors/rollbar.md),
+[Prometheus](/docs/interceptors/prometheus.md).
 
 → [Read more about core interceptors](docs/interceptors.md#core-interceptors)
 

--- a/docs/interceptors/prometheus.md
+++ b/docs/interceptors/prometheus.md
@@ -1,0 +1,18 @@
+# Prometheus Interceptor
+
+Logs basic request/response information to prometheus.
+
+```ruby
+  require 'prometheus/client'
+  LHC::Prometheus.client = Prometheus::Client
+  LHC::Prometheus.namespace = 'web_location_app'
+  LHC.config.interceptors = [LHC::Prometheus]
+```
+
+```ruby
+  LHC.get('http://local.ch')
+```
+
+- Creates a promethues counter that receives additional meta information for: `:code`, `:success` and `:timeout`.
+
+- Creates a promethues histogram for response times in milliseconds.

--- a/lhc.gemspec
+++ b/lhc.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rubocop', '~> 0.36.0'
   s.add_development_dependency 'rubocop-rspec'
+  s.add_development_dependency 'prometheus-client', '~> 0.7.1'
 
   s.license = 'GPL-3'
 end

--- a/lib/lhc.rb
+++ b/lib/lhc.rb
@@ -16,6 +16,8 @@ module LHC
     'lhc/interceptors/auth'
   autoload :Caching,
     'lhc/interceptors/caching'
+  autoload :Prometheus,
+    'lhc/interceptors/prometheus'
   autoload :Config,
     'lhc/config'
   autoload :Endpoint,

--- a/lib/lhc/interceptors/prometheus.rb
+++ b/lib/lhc/interceptors/prometheus.rb
@@ -1,0 +1,38 @@
+class LHC::Prometheus < LHC::Interceptor
+  include ActiveSupport::Configurable
+
+  config_accessor :client, :namespace
+
+  class << self
+    attr_accessor :registered
+  end
+
+  def self.request_key
+    [LHC::Prometheus.namespace, 'lhc_requests'].join('_').to_sym
+  end
+
+  def self.times_key
+    [LHC::Prometheus.namespace, 'lhc_times'].join('_').to_sym
+  end
+
+  def initialize
+    return if LHC::Prometheus.registered || LHC::Prometheus.client.blank?
+    LHC::Prometheus.client.registry.counter(LHC::Prometheus.request_key, 'Counter of all LHC requests.')
+    LHC::Prometheus.client.registry.histogram(LHC::Prometheus.times_key, 'Times for all LHC requests.')
+    LHC::Prometheus.registered = true
+  end
+
+  def after_response(response)
+    return if !LHC::Prometheus.registered || LHC::Prometheus.client.blank?
+    LHC::Prometheus.client.registry
+      .get(LHC::Prometheus.request_key)
+      .increment(
+        code: response.code,
+        success: response.success?,
+        timeout: response.timeout?
+      )
+    LHC::Prometheus.client.registry
+      .get(LHC::Prometheus.times_key)
+      .observe({}, response.time_ms)
+  end
+end

--- a/lib/lhc/response.rb
+++ b/lib/lhc/response.rb
@@ -32,9 +32,14 @@ class LHC::Response
     body_replacement || raw.body.presence
   end
 
-  # Provides response time in ms.
+  # Provides response time in seconds
   def time
-    (raw.time || 0) * 1000
+    time_ms * 1000
+  end
+
+  # Provides response time in milliseconds
+  def time_ms
+    raw.time || 0
   end
 
   def timeout?

--- a/spec/interceptors/prometheus_spec.rb
+++ b/spec/interceptors/prometheus_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+require 'prometheus/client'
+
+describe LHC::Prometheus do
+  before(:each) do
+    LHC.config.interceptors = [LHC::Prometheus]
+    LHC::Prometheus.client = Prometheus::Client
+    LHC::Prometheus.namespace = 'test_app'
+    stub_request(:get, 'http://local.ch')
+    expect(Prometheus::Client).to receive(:registry).and_call_original.at_least(:once)
+  end
+
+  let(:client) { double("prometheus/client") }
+
+  context 'registering' do
+    it 'creates a counter and histogram registry in the prometheus client' do
+      expect(Prometheus::Client.registry).to receive(:counter).and_call_original.once
+        .with(:test_app_lhc_requests, 'Counter of all LHC requests.')
+      expect(Prometheus::Client.registry).to receive(:histogram).and_call_original.once
+        .with(:test_app_lhc_times, 'Times for all LHC requests.')
+
+      LHC.get('http://local.ch')
+      LHC.get('http://local.ch') # second request, registration should happen only once
+    end
+  end
+
+  context 'logging' do
+    let(:requests_registry_double) { double('requests_registry_double') }
+    let(:times_registry_double) { double('times_registry_double') }
+
+    it 'logs monitoring information to the created registries' do
+      expect(Prometheus::Client.registry).to receive(:get).and_return(requests_registry_double).once
+        .with(:test_app_lhc_requests)
+      expect(Prometheus::Client.registry).to receive(:get).and_return(times_registry_double).once
+        .with(:test_app_lhc_times)
+
+      expect(requests_registry_double).to receive(:increment).once
+        .with(
+          code: 200,
+          success: true,
+          timeout: false
+        )
+      expect(times_registry_double).to receive(:observe).once
+        .with({}, 0)
+
+      LHC.get('http://local.ch')
+    end
+  end
+end

--- a/spec/response/time_spec.rb
+++ b/spec/response/time_spec.rb
@@ -6,9 +6,14 @@ describe LHC::Response do
 
     let(:raw_response) { OpenStruct.new(time: time) }
 
-    it 'provides response time in milliseconds' do
+    it 'provides response time in seconds' do
       response = LHC::Response.new(raw_response, nil)
       expect(response.time).to eq time * 1000
+    end
+
+    it 'provides response time in seconds' do
+      response = LHC::Response.new(raw_response, nil)
+      expect(response.time_ms).to eq time
     end
   end
 end


### PR DESCRIPTION
_MINOR_

# Prometheus Interceptor

Logs basic request/response information to prometheus.

```ruby
  require 'prometheus/client'
  LHC::Prometheus.client = Prometheus::Client
  LHC::Prometheus.namespace = 'web_location_app'
  LHC.config.interceptors = [LHC::Prometheus]
```

```ruby
  LHC.get('http://local.ch')
```

- Creates a promethues counter that receives additional meta information for: `:code`, `:success` and `:timeout`.

- Creates a promethues histogram for response times in milliseconds.

