### PR TITLE
Retry interceptor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,3 +38,6 @@ RSpec/VerifiedDoubles:
 
 Style/RedundantReturn:
   Enabled: false
+
+RSpec/InstanceVariable:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ like
 [Caching](/docs/interceptors/caching.md),
 [Monitoring](/docs/interceptors/monitoring.md),
 [Authentication](/docs/interceptors/authentication.md),
+[Retry](/docs/interceptors/retry.md),
 [Rollbar](/docs/interceptors/rollbar.md),
 [Prometheus](/docs/interceptors/prometheus.md).
 

--- a/docs/interceptors/retry.md
+++ b/docs/interceptors/retry.md
@@ -1,0 +1,24 @@
+# Retry Interceptor
+
+If you enable the retry interceptor, you can have lhc retry requests for you:
+
+```ruby
+  LHC.config.interceptors = [LHC::Retry]
+  response = LHC.get('http://local.ch', retry: true)
+```
+
+It will try to retry the request up to 3 times (default) internally, before it passes the last response back, or raises an error for the last response.
+
+Consider, that all other interceptors will run for every single retry.
+
+## Limit the amount of retries while making the request
+
+```ruby
+  LHC.get('http://local.ch', retry: { max: 1 })
+```
+
+## Change the default maximum of retries of the retry interceptor
+
+```ruby
+  LHC::Retry.max = 3
+```

--- a/lib/lhc.rb
+++ b/lib/lhc.rb
@@ -18,6 +18,8 @@ module LHC
     'lhc/interceptors/caching'
   autoload :Prometheus,
     'lhc/interceptors/prometheus'
+  autoload :Retry,
+    'lhc/interceptors/retry'
   autoload :Config,
     'lhc/config'
   autoload :Endpoint,

--- a/lib/lhc/interceptors/retry.rb
+++ b/lib/lhc/interceptors/retry.rb
@@ -1,0 +1,38 @@
+class LHC::Retry < LHC::Interceptor
+  attr_accessor :retries, :current_retry
+
+  class << self
+    attr_accessor :max
+  end
+
+  def after_response(response)
+    response.request.options[:retries] ||= 0
+    return unless retry?(response.request)
+    response.request.options[:retries] += 1
+    current_retry = response.request.options[:retries]
+    begin
+      response.request.run!
+    rescue LHC::Error
+      return
+    end
+    response.request.response if current_retry == response.request.options[:retries]
+  end
+
+  private
+
+  def retry?(request)
+    return false if request.response.success?
+    return false unless request.options.dig(:retry)
+    request.options[:retries] < max(request)
+  end
+
+  def max(request)
+    options(request).is_a?(Hash) ? options(request).fetch(:max, LHC::Retry.max) : LHC::Retry.max
+  end
+
+  def options(request)
+    @options ||= request.options.dig(:retry)
+  end
+end
+
+LHC::Retry.max = 3

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -20,7 +20,7 @@ class LHC::Request
     self.raw = create_request
     self.format = options.delete('format') || LHC::Formats::JSON.new
     iprocessor.intercept(:before_request, self)
-    raw.run if self_executing && !response
+    run! if self_executing && !response
   end
 
   def url
@@ -41,6 +41,10 @@ class LHC::Request
 
   def error_ignored?
     ignore_error?
+  end
+
+  def run!
+    raw.run
   end
 
   private
@@ -100,7 +104,7 @@ class LHC::Request
   end
 
   def on_complete(response)
-    self.response ||= LHC::Response.new(response, self)
+    self.response = LHC::Response.new(response, self)
     iprocessor.intercept(:after_response, self.response)
     handle_error(self.response) unless self.response.success?
   end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION ||= "6.6.0"
+  VERSION ||= "6.7.0"
 end

--- a/spec/interceptors/retry/main_spec.rb
+++ b/spec/interceptors/retry/main_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe LHC::Rollbar do
+  before(:each) do
+    LHC.config.interceptors = [LHC::Retry]
+  end
+
+  let(:request_stub) do
+    @retry_count = 0
+    stub_request(:get, 'http://local.ch').to_return do |_|
+      if @retry_count == max_retry_count
+        { status: 200 }
+      else
+        @retry_count += 1
+        { status: 500 }
+      end
+    end
+  end
+
+  let(:max_retry_count) { 3 }
+
+  it 'retries a request up to 3 times (default)' do
+    request_stub
+    response = LHC.get('http://local.ch', retry: true)
+    expect(response.success?).to eq true
+    expect(response.code).to eq 200
+    expect(request_stub).to have_been_requested.times(4)
+  end
+
+  context 'retry only once' do
+    let(:retry_options) { { max: 1 } }
+    let(:max_retry_count) { 1 }
+
+    it 'retries only once' do
+      request_stub
+      response = LHC.get('http://local.ch', retry: { max: 1 })
+      expect(response.success?).to eq true
+      expect(response.code).to eq 200
+      expect(request_stub).to have_been_requested.times(2)
+    end
+  end
+end

--- a/spec/request/parallel_requests_spec.rb
+++ b/spec/request/parallel_requests_spec.rb
@@ -26,7 +26,6 @@ describe LHC::Request do
       LHC.configure { |c| c.interceptors = [TestInterceptor] }
     end
 
-    # rubocop:disable RSpec/InstanceVariable
     it 'calls interceptors also for parallel requests' do
       stub_parallel_requests
       @called = 0
@@ -35,6 +34,5 @@ describe LHC::Request do
       LHC.request(request_options)
       expect(@called).to eq 2
     end
-    # rubocop:enable RSpec/InstanceVariable
   end
 end


### PR DESCRIPTION
_MINOR_

Mainly needed for Uberall (my presence sync) right now ;(

# Retry Interceptor

If you enable the retry interceptor, you can have lhc retry requests for you:

```ruby
  LHC.config.interceptors = [LHC::Retry]
  response = LHC.get('http://local.ch', retry: true)
```

It will try to retry the request up to 3 times (default) internally, before it passes the last response back, or raises an error for the last response.

Consider, that all other interceptors will run for every single retry.

## Limit the amount of retries while making the request

```ruby
  LHC.get('http://local.ch', retry: { max: 1 })
```

## Change the default maximum of retries of the retry interceptor

```ruby
  LHC::Retry.max = 3
```
