### PR TITLE
Fix missing URI require

### DIFF
--- a/lib/lhc/endpoint.rb
+++ b/lib/lhc/endpoint.rb
@@ -1,3 +1,4 @@
+require 'uri'
 # frozen_string_literal: true
 # An endpoint is an url that leads to a backend resource.
 # The url can also be an url-template.

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION ||= "6.7.0"
+  VERSION ||= '6.7.1'
 end


### PR DESCRIPTION
# Patch

Missing a `require 'uri'` in endpoint file.