### PR TITLE
Enable params_encoding option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ LHC.get('http://local.ch?q=some space', url_encoding: false)
 # http://local.ch?q=some space
 ```
 
+### Array Parameter Encoding
+
+LHC can encode array parameters in URLs in two ways. The default is `:rack` which generates URL parameters compatible with Rack and Rails.
+
+```ruby
+LHC.get('http://local.ch', params: { q: [1, 2] })
+# http://local.ch?q[]=1&q[]=2
+```
+
+Some Java-based apps expect their arrays in the `:multi` format:
+
+```ruby
+LHC.get('http://local.ch', params: { q: [1, 2] }, params_encoding: :multi)
+# http://local.ch?q=1&q=2
+```
+
 ## Configuration
 
 You can configure global endpoints, placeholders and interceptors.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ DON'T
 LHC.get('http://local.ch?q=Restaurant')
 ```
 
+### Array Parameter Encoding
+
+LHC can encode array parameters in URLs in two ways. The default is `:rack` which generates URL parameters compatible with Rack and Rails.
+
+```ruby
+LHC.get('http://local.ch', params: { q: [1, 2] })
+# http://local.ch?q[]=1&q[]=2
+```
+
+Some Java-based apps expect their arrays in the `:multi` format:
+
+```ruby
+LHC.get('http://local.ch', params: { q: [1, 2] }, params_encoding: :multi)
+# http://local.ch?q=1&q=2
+```
+
 ## Encoding
 
 LHC, by default, encodes urls:
@@ -129,22 +145,6 @@ which can be disabled:
 ```ruby
 LHC.get('http://local.ch?q=some space', url_encoding: false)
 # http://local.ch?q=some space
-```
-
-### Array Parameter Encoding
-
-LHC can encode array parameters in URLs in two ways. The default is `:rack` which generates URL parameters compatible with Rack and Rails.
-
-```ruby
-LHC.get('http://local.ch', params: { q: [1, 2] })
-# http://local.ch?q[]=1&q[]=2
-```
-
-Some Java-based apps expect their arrays in the `:multi` format:
-
-```ruby
-LHC.get('http://local.ch', params: { q: [1, 2] }, params_encoding: :multi)
-# http://local.ch?q=1&q=2
 ```
 
 ## Configuration

--- a/lhc.gemspec
+++ b/lhc.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.requirements << 'Ruby >= 2.0.0'
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_dependency 'typhoeus'
+  s.add_dependency 'typhoeus', '>= 0.11'
   s.add_dependency 'activesupport', '>= 4.2'
   s.add_dependency 'addressable'
 

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -6,7 +6,7 @@ require 'active_support/core_ext/object/deep_dup'
 # and it communicates with interceptors.
 class LHC::Request
 
-  TYPHOEUS_OPTIONS ||= [:params, :method, :body, :headers, :follow_location]
+  TYPHOEUS_OPTIONS ||= [:params, :method, :body, :headers, :follow_location, :params_encoding]
 
   attr_accessor :response, :options, :raw, :format, :error_handler, :errors_ignored
 

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION ||= '7.2.0'
+  VERSION ||= '7.3.0'
 end

--- a/spec/request/params_encoding_spec.rb
+++ b/spec/request/params_encoding_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe LHC::Request do
+  context 'without an encoding setting' do
+    it 'encodes array params in default rack format' do
+      stub_request(:get, 'http://datastore/q?a%5B%5D=1&a%5B%5D=2&a%5B%5D=3')
+      LHC.get('http://datastore/q', params: { a: [1, 2, 3] })
+    end
+  end
+
+  context 'with encoding set to :rack' do
+    it 'encodes array params in rack format' do
+      stub_request(:get, 'http://datastore/q?a%5B%5D=1&a%5B%5D=2&a%5B%5D=3')
+      LHC.get('http://datastore/q', params: { a: [1, 2, 3] }, params_encoding: :rack)
+    end
+  end
+
+  context 'with encoding set to :multi' do
+    it 'encodes array params in multi format' do
+      stub_request(:get, 'http://datastore/q?a=1&a=2&a=3')
+      LHC.get('http://datastore/q', params: { a: [1, 2, 3] }, params_encoding: :multi)
+    end
+  end
+end


### PR DESCRIPTION
Allows to use the option `params_encoding` to encode array parameters in different ways for APIs.