### PR TITLE
New default connect timeout

### DIFF
--- a/docs/interceptors/default_timeout.md
+++ b/docs/interceptors/default_timeout.md
@@ -7,11 +7,11 @@ Applies default timeout values to all requests made in an application, that uses
 ```
 
 `timeout` default: 15 seconds
-`connecttimeout` default: 1 second
+`connecttimeout` default: 2 second
 
 ## Overwrite defaults
 
 ```ruby
 LHC::DefaultTimeout.timeout = 5 # seconds
-LHC::DefaultTimeout.connecttimeout = 2 # seconds
+LHC::DefaultTimeout.connecttimeout = 3 # seconds
 ```

--- a/docs/interceptors/default_timeout.md
+++ b/docs/interceptors/default_timeout.md
@@ -7,7 +7,7 @@ Applies default timeout values to all requests made in an application, that uses
 ```
 
 `timeout` default: 15 seconds
-`connecttimeout` default: 2 second
+`connecttimeout` default: 2 seconds
 
 ## Overwrite defaults
 

--- a/lib/lhc/interceptors/default_timeout.rb
+++ b/lib/lhc/interceptors/default_timeout.rb
@@ -3,7 +3,7 @@ class LHC::DefaultTimeout < LHC::Interceptor
 
   config_accessor :timeout, :connecttimeout
 
-  CONNECTTIMEOUT = 2 # second
+  CONNECTTIMEOUT = 2 # seconds
   TIMEOUT = 15 # seconds
 
   def before_raw_request(request)

--- a/lib/lhc/interceptors/default_timeout.rb
+++ b/lib/lhc/interceptors/default_timeout.rb
@@ -3,7 +3,7 @@ class LHC::DefaultTimeout < LHC::Interceptor
 
   config_accessor :timeout, :connecttimeout
 
-  CONNECTTIMEOUT = 1 # second
+  CONNECTTIMEOUT = 2 # second
   TIMEOUT = 15 # seconds
 
   def before_raw_request(request)

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION ||= '7.3.1'
+  VERSION ||= '7.3.2'
 end

--- a/spec/interceptors/default_timeout/main_spec.rb
+++ b/spec/interceptors/default_timeout/main_spec.rb
@@ -12,7 +12,7 @@ describe LHC::DefaultTimeout do
   it 'applies default timeouts to all requests made' do
     stub
     expect_any_instance_of(Ethon::Easy).to receive(:http_request)
-      .with(anything, anything, hash_including(timeout: 15, connecttimeout: 1)).and_call_original
+      .with(anything, anything, hash_including(timeout: 15, connecttimeout: 2)).and_call_original
     LHC.get('http://local.ch')
   end
 


### PR DESCRIPTION
In one of our applications (salesbutler) we had a lot of problems with a default connecttimeout of 1 second. After running a test with 2 seconds, it seems to be the way better default for our infrastructure.