### PR TITLE
add require for deep_symbolize_keys

### DIFF
--- a/lib/lhc.rb
+++ b/lib/lhc.rb
@@ -1,5 +1,6 @@
 require 'typhoeus'
 require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/hash/keys'
 
 module LHC
   autoload :BasicMethodsConcern,

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION ||= '7.3.2'
+  VERSION ||= '7.3.3'
 end

--- a/spec/basic_methods/request_without_rails_spec.rb
+++ b/spec/basic_methods/request_without_rails_spec.rb
@@ -1,9 +1,28 @@
 require 'spec_helper'
 
 describe LHC do
-  context 'request' do
+  context 'GET' do
+    before do
+      stub_request(:get, "http://datastore/v2/feedbacks").to_return(status: 200, body: "{}")
+    end
     it "is able to call .request without LHC raising NoMethodError: undefined method `blank?' for nil:NilClass when calling it outside of the rails context" do
-      expect { LHC.request(url: "http://datastore/v2/feedbacks", method: :get) }.not_to raise_error(NoMethodError)
+      expect { LHC.request(url: "http://datastore/v2/feedbacks", method: :get) }.not_to raise_error
+    end
+  end
+
+  context 'POST' do
+    before do
+      stub_request(:post, "http://datastore/v2/feedbacks").to_return(status: 200, body: "{}")
+    end
+
+    it "is able to call .request without LHC raising NoMethodError: undefined method `deep_symbolize_keys' for {}:Hash" do
+      options = {
+        url: "http://datastore/v2/feedbacks",
+        method: :post,
+        body: "{}",
+        headers: { 'Content-Type' => 'application/json' }
+      }
+      expect { LHC.request(options) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
quick fix for missing `deep_symbolize_keys` in apps that do not operate under rails