### PR TITLE
Simplify making JSON requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ LHC.json.get(options)
 
 Currently supported formats: `json`
 
+If formats are used, headers for `Content-Type` and `Accept` are set by lhc, but also http bodies are translated by LHC, so you can pass bodies as ruby objects:
+
+```ruby
+LHC.json.post('http://slack', body: { text: 'Hi there' })
+# Content-Type: application/json
+# Accept: application/json
+# Translates body to "{\"text\":\"Hi there\"}" before sending
+```
+
 ## A request from scratch
 
 ```ruby
@@ -88,12 +97,13 @@ LHC.get('http://local.ch', followlocation: true)
 
 ## Transfer data through the body
 
-Data that is transfered using the HTTP request body is transfered as you provide it.
-Also consider setting the http header for content-type.
+Data that is transfered using the HTTP request body is transfered using the selected format, or the default `json`, so you need to provide it as a ruby object.
+
+Also consider setting the http header for content-type or use one of the provided formats, like `LHC.json`.
 
 ```ruby
   LHC.post('http://datastore/v2/feedbacks',
-    body: feedback.to_json,
+    body: feedback,
     headers: { 'Content-Type' => 'application/json' }
   )
 ```

--- a/lib/lhc/formats/json.rb
+++ b/lib/lhc/formats/json.rb
@@ -10,12 +10,16 @@ module LHC::Formats
       super(options)
     end
 
-    def as_json(response)
-      parse(response, Hash)
+    def as_json(input)
+      parse(input, Hash)
     end
 
-    def as_open_struct(response)
-      parse(response, OpenStruct)
+    def as_open_struct(input)
+      parse(input, OpenStruct)
+    end
+
+    def to_body(input)
+      input.to_json
     end
 
     def to_s
@@ -28,10 +32,10 @@ module LHC::Formats
 
     private
 
-    def parse(response, object_class)
-      ::JSON.parse(response.body, object_class: object_class)
+    def parse(input, object_class)
+      ::JSON.parse(input, object_class: object_class)
     rescue ::JSON::ParserError => e
-      raise LHC::ParserError.new(e.message, response)
+      raise LHC::ParserError.new(e.message, input)
     end
   end
 end

--- a/lib/lhc/response/data/base.rb
+++ b/lib/lhc/response/data/base.rb
@@ -2,7 +2,7 @@
 # but made accssible in the ruby world
 module LHC::Response::Data::Base
   def as_json
-    @json ||= (@data || response.format.as_json(response))
+    @json ||= (@data || response.format.as_json(response.body))
   end
 
   def as_open_struct
@@ -10,7 +10,7 @@ module LHC::Response::Data::Base
       if @data
         JSON.parse(@data.to_json, object_class: OpenStruct)
       else
-        response.format.as_open_struct(response)
+        response.format.as_open_struct(response.body)
       end
   end
 

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION ||= '8.1.0'
+  VERSION ||= '9.0.0'
 end

--- a/spec/basic_methods/post_spec.rb
+++ b/spec/basic_methods/post_spec.rb
@@ -17,23 +17,23 @@ describe LHC do
     end
 
     it 'does a post request when providing a complete url' do
-      LHC.post('http://datastore/v2/feedbacks', body: feedback.to_json)
+      LHC.post('http://datastore/v2/feedbacks', body: feedback)
     end
 
     it 'does a post request when providing the name of a configured endpoint' do
       url = 'http://{+datastore}/v2/feedbacks'
       options = { params: { datastore: 'datastore' } }
       LHC.configure { |c| c.endpoint(:feedbacks, url, options) }
-      LHC.post(:feedbacks, body: feedback.to_json)
+      LHC.post(:feedbacks, body: feedback)
     end
 
     it 'it makes response data available in a rails way' do
-      response = LHC.post('http://datastore/v2/feedbacks', body: feedback.to_json)
+      response = LHC.post('http://datastore/v2/feedbacks', body: feedback)
       expect(response.data.source_id).to eq 'aaa'
     end
 
     it 'provides response headers' do
-      response = LHC.post('http://datastore/v2/feedbacks', body: feedback.to_json)
+      response = LHC.post('http://datastore/v2/feedbacks', body: feedback)
       expect(response.headers).to be
     end
   end

--- a/spec/basic_methods/put_spec.rb
+++ b/spec/basic_methods/put_spec.rb
@@ -23,23 +23,23 @@ describe LHC do
     end
 
     it 'does a post request when providing a complete url' do
-      LHC.put('http://datastore/v2/feedbacks', body: change.to_json)
+      LHC.put('http://datastore/v2/feedbacks', body: change)
     end
 
     it 'does a post request when providing the name of a configured endpoint' do
       url = 'http://{+datastore}/v2/feedbacks'
       options = { params: { datastore: 'datastore' } }
       LHC.configure { |c| c.endpoint(:feedbacks, url, options) }
-      LHC.put(:feedbacks, body: change.to_json)
+      LHC.put(:feedbacks, body: change)
     end
 
     it 'it makes response data available in a rails way' do
-      response = LHC.put('http://datastore/v2/feedbacks', body: change.to_json)
+      response = LHC.put('http://datastore/v2/feedbacks', body: change)
       expect(response.data.recommended).to eq false
     end
 
     it 'provides response headers' do
-      response = LHC.put('http://datastore/v2/feedbacks', body: change.to_json)
+      response = LHC.put('http://datastore/v2/feedbacks', body: change)
       expect(response.headers).to be
     end
   end

--- a/spec/basic_methods/request_without_rails_spec.rb
+++ b/spec/basic_methods/request_without_rails_spec.rb
@@ -19,7 +19,7 @@ describe LHC do
       options = {
         url: "http://datastore/v2/feedbacks",
         method: :post,
-        body: "{}",
+        body: {},
         headers: { 'Content-Type' => 'application/json' }
       }
       expect { LHC.request(options) }.not_to raise_error

--- a/spec/request/url_patterns_spec.rb
+++ b/spec/request/url_patterns_spec.rb
@@ -18,6 +18,6 @@ describe LHC::Request do
 
   it 'considers body when compiling urls' do
     stub_request(:post, "http://datastore:8080/v2/places/123")
-    LHC.json.post('http://datastore:8080/v2/places/{id}', body: { id: 123 }.to_json)
+    LHC.json.post('http://datastore:8080/v2/places/{id}', body: { id: 123 })
   end
 end


### PR DESCRIPTION
MAJOR (not backwards compatible)

## Before

Even though JSON already has been our default format when performing HTTP requests ([see here](https://github.com/local-ch/lhc/blob/master/lib/lhc/request.rb#L22)), we were still obliged to translate the body option to json, before passed to LHC, when performing requests having an HTTP body.

```ruby
LHC.post('http://datastore', body: { name: 'Steve' }.to_json)
```

This also led to inelegant implementations, assuming or hard-code checking for "application/json" or a json-like string in the body  – e.g. when compiling the url ([see here](https://github.com/local-ch/lhc/blob/master/lib/lhc/request.rb#L103)) – and even though we have the http message "format" abstracted in LHC ([see here](https://github.com/local-ch/lhc/blob/master/lib/lhc/formats/json.rb))

## Now

Body translation is now also performed by LHC. So we can continue working with plain ruby objects, and leave the rest to the selected LHC format or `json` as default. Which allows to cleanup the internal code, and prevents us from using `.to_json` everytime we pass a body.

```ruby
LHC.post('http://datastore', body: { name: 'Steve' })
```

## How to migrate

Simply remove all `.to_json` when handing over ruby objects to LHC as a body.

Change
```ruby
LHC.post('http://datastore', body: { name: 'Steve' }.to_json)
```
to 
```ruby
LHC.post('http://datastore', body: { name: 'Steve' })
```
