### PR TITLE
Adding charset when setting media type headeres

### DIFF
--- a/lib/lhc/formats/json.rb
+++ b/lib/lhc/formats/json.rb
@@ -4,8 +4,8 @@ module LHC::Formats
 
     def self.request(options)
       options[:headers] ||= {}
-      options[:headers]['Content-Type'] = 'application/json'
-      options[:headers]['Accept'] = 'application/json'
+      options[:headers]['Content-Type'] = 'application/json; charset=utf-8'
+      options[:headers]['Accept'] = 'application/json; charset=utf-8'
       options[:format] = new
       super(options)
     end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION ||= '9.0.0'
+  VERSION ||= '9.1.0'
 end

--- a/spec/basic_methods/get_spec.rb
+++ b/spec/basic_methods/get_spec.rb
@@ -35,7 +35,7 @@ describe LHC do
 
   context 'get json' do
     before(:each) do
-      stub_request(:get, 'http://datastore/v2/feedbacks').with(headers: { 'Content-Type' => 'application/json' })
+      stub_request(:get, 'http://datastore/v2/feedbacks').with(headers: { 'Content-Type' => 'application/json; charset=utf-8' })
         .to_return(body: { some: 'json' }.to_json)
     end
 

--- a/spec/formats/json_spec.rb
+++ b/spec/formats/json_spec.rb
@@ -4,7 +4,7 @@ describe LHC do
   context 'formats' do
     it 'adds Content-Type and Accept Headers to the request' do
       stub_request(:get, "http://local.ch/")
-        .with(headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' })
+        .with(headers: { 'Accept' => 'application/json; charset=utf-8', 'Content-Type' => 'application/json; charset=utf-8' })
         .to_return(body: {}.to_json)
       LHC.json.get('http://local.ch')
     end

--- a/spec/response/data_accessor_spec.rb
+++ b/spec/response/data_accessor_spec.rb
@@ -4,7 +4,7 @@ describe LHC do
   context 'data accessor (hash with indifferent access)' do
     before(:each) do
       stub_request(:get, "http://local.ch/")
-        .with(headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' })
+        .with(headers: { 'Accept' => 'application/json; charset=utf-8', 'Content-Type' => 'application/json; charset=utf-8' })
         .to_return(body: { 'MyProp' => 'MyValue' }.to_json)
     end
 


### PR DESCRIPTION
Minor (backwards compatible)

A lot of APIs actually require a explicit charset to be defined together with the content type (e.g. Slack).

## Before:

LHC was not setting the charset:

```
Content-Type: application/json
Accept: application/json
```

## Now:

LHC adds charset

```
Content-Type: application/json; charset=utf-8
Accept: application/json; charset=utf-8
```