### PR TITLE
Fix zipkin 8.1.0

### DIFF
--- a/lib/lhc/interceptors/zipkin.rb
+++ b/lib/lhc/interceptors/zipkin.rb
@@ -38,11 +38,11 @@ class LHC::Zipkin < LHC::Interceptor
     record_end
   end
 
-  # register a new span with zipkin tracer
   def trace_id
     @trace_id ||= ZipkinTracer::TraceGenerator.new.next_trace_id
   end
 
+  # register a new span with zipkin tracer
   def span
     @span ||= ::Trace.tracer.start_span(trace_id, url.path)
   end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION ||= '8.1.0'
+  VERSION ||= '8.1.1'
 end

--- a/spec/interceptors/zipkin/distributed_tracing_spec.rb
+++ b/spec/interceptors/zipkin/distributed_tracing_spec.rb
@@ -13,7 +13,7 @@ describe LHC::Zipkin do
         trace_id: 'trace_id',
         parent_id: 'parent_id',
         span_id: 'span_id',
-        sampled: 'sampled',
+        sampled: true,
         flags: 'flags'
       )
     end
@@ -23,7 +23,7 @@ describe LHC::Zipkin do
       expect(headers['X-B3-TraceId']).to eq('trace_id')
       expect(headers['X-B3-ParentSpanId']).to eq('parent_id')
       expect(headers['X-B3-SpanId']).to eq('span_id')
-      expect(headers['X-B3-Sampled']).to eq('sampled')
+      expect(headers['X-B3-Sampled']).to eq('true')
       expect(headers['X-B3-Flags']).to eq('flags')
     end
   end
@@ -47,6 +47,62 @@ describe LHC::Zipkin do
       expect(headers['X-B3-SpanId']).to be_nil
       expect(headers['X-B3-Sampled']).to be_nil
       expect(headers['X-B3-Flags']).to be_nil
+    end
+  end
+
+  describe 'creating new spans' do
+    context 'sampled? is false' do
+      before(:all) do
+        ::ZipkinTracer::TraceContainer.setup_mock(
+          trace_id: 'trace_id',
+          parent_id: 'parent_id',
+          span_id: 'span_id',
+          sampled: false,
+          flags: 'flags'
+        )
+      end
+
+      it 'adds the proper X-B3 headers' do
+        headers = LHC.get(:local).request.headers
+        expect(headers['X-B3-TraceId']).to eq('trace_id')
+        expect(headers['X-B3-ParentSpanId']).to eq('parent_id')
+        expect(headers['X-B3-SpanId']).to eq('span_id')
+        expect(headers['X-B3-Sampled']).to eq('false')
+        expect(headers['X-B3-Flags']).to eq('flags')
+      end
+
+      it 'does not register a new span' do
+        # ensure no span was registered, by checking no call on span
+        expect_any_instance_of(described_class).not_to receive(:span).and_call_original
+        LHC.get(:local)
+      end
+    end
+
+    context 'sampled? is true' do
+      before(:all) do
+        ::ZipkinTracer::TraceContainer.setup_mock(
+          trace_id: 'trace_id',
+          parent_id: 'parent_id',
+          span_id: 'span_id',
+          sampled: true,
+          flags: 'flags'
+        )
+      end
+
+      it 'adds the proper X-B3 headers' do
+        headers = LHC.get(:local).request.headers
+        expect(headers['X-B3-TraceId']).to eq('trace_id')
+        expect(headers['X-B3-ParentSpanId']).to eq('parent_id')
+        expect(headers['X-B3-SpanId']).to eq('span_id')
+        expect(headers['X-B3-Sampled']).to eq('true')
+        expect(headers['X-B3-Flags']).to eq('flags')
+      end
+
+      it 'does register a new span' do
+        # ensure a span was registered, by checking call on span
+        expect_any_instance_of(described_class).to receive(:span).at_least(1).times.and_call_original
+        LHC.get(:local)
+      end
     end
   end
 end

--- a/spec/support/zipkin_mock.rb
+++ b/spec/support/zipkin_mock.rb
@@ -42,7 +42,7 @@ module ZipkinTracer
     end
 
     def sampled
-      'sampled'
+      ZipkinTracer::TraceContainer.current.sampled
     end
 
     def flags
@@ -50,7 +50,7 @@ module ZipkinTracer
     end
 
     def sampled?
-      true
+      ZipkinTracer::TraceContainer.current.sampled
     end
   end
 


### PR DESCRIPTION
after letting the implementation run in the real-world. @golonzovsky and I have found an issue with spans that were not being added to parent. 

turns out my implementation created unecessary spans that lead to that behavior.

this PR ensures:

- B3 headers are always sent even if `sampled?` is `false`
- however a span is only created if `sampled?` is `true`