### PR TITLE
Logging Interceptor

### DIFF
--- a/docs/interceptors/logging.md
+++ b/docs/interceptors/logging.md
@@ -1,0 +1,29 @@
+# Logging Interceptor
+
+The logging interceptor logs all requests done with LHC to the Rails logs.
+
+## Installation
+
+```ruby
+  LHC.config.interceptors = [LHC::Logging]
+
+  LHC::Logging.logger = Rails.logger  
+```
+
+## What and how it logs
+
+The logging Interceptor logs basic information about the request and the response:
+
+```ruby
+LHC.get('http://local.ch')
+# Before LHC request<70128730317500> GET http://local.ch at 2018-05-23T07:53:19+02:00 Params={} Headers={\"User-Agent\"=>\"Typhoeus - https://github.com/typhoeus/typhoeus\", \"Expect\"=>\"\"}
+# After LHC response for request<70128730317500>: GET http://local.ch at 2018-05-23T07:53:28+02:00 Time=0ms URL=http://local.ch:80/
+```
+
+## Configure
+
+You can configure the logger beeing used by the logging interceptor:
+
+```ruby
+LHC::Logging.logger = Another::Logger
+```

--- a/lib/lhc.rb
+++ b/lib/lhc.rb
@@ -18,12 +18,15 @@ module LHC
     'lhc/interceptors/auth'
   autoload :Caching,
     'lhc/interceptors/caching'
+  autoload :DefaultTimeout,
+    'lhc/interceptors/default_timeout'
+  autoload :Logging,
+    'lhc/interceptors/logging'
   autoload :Prometheus,
     'lhc/interceptors/prometheus'
   autoload :Retry,
     'lhc/interceptors/retry'
-  autoload :DefaultTimeout,
-    'lhc/interceptors/default_timeout'
+
   autoload :Config,
     'lhc/config'
   autoload :Endpoint,

--- a/lib/lhc/interceptors/logging.rb
+++ b/lib/lhc/interceptors/logging.rb
@@ -1,0 +1,19 @@
+class LHC::Logging < LHC::Interceptor
+
+  include ActiveSupport::Configurable
+  config_accessor :logger
+
+  def before_request
+    return unless logger
+    logger.info(
+      "Before LHC request<#{request.object_id}> #{request.method.upcase} #{request.url} at #{DateTime.now} Params=#{request.params} Headers=#{request.headers}"
+    )
+  end
+
+  def after_response
+    return unless logger
+    logger.info(
+      "After LHC response for request<#{request.object_id}> #{request.method.upcase} #{request.url} at #{DateTime.now} Time=#{response.time_ms}ms URL=#{response.effective_url}"
+    )
+  end
+end

--- a/spec/interceptors/logging/main_spec.rb
+++ b/spec/interceptors/logging/main_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe LHC::Logging do
+
+  let(:logger) { spy('logger') }
+
+  before(:each) do
+    LHC.config.interceptors = [LHC::Logging]
+    LHC::Logging.logger = logger
+  end
+
+  it 'does log information before and after every request made with LHC' do
+    stub_request(:get, 'http://local.ch').to_return(status: 200)
+    LHC.get('http://local.ch')
+    expect(logger).to have_received(:info).once.with(
+      %r{Before LHC request<\d+> GET http://local.ch at \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} Params={} Headers={.*?}}
+    )
+    expect(logger).to have_received(:info).once.with(
+      %r{After LHC response for request<\d+> GET http://local.ch at \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} Time=0ms URL=http://local.ch:80/}
+    )
+  end
+end

--- a/spec/interceptors/logging/main_spec.rb
+++ b/spec/interceptors/logging/main_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe LHC::Logging do
-
   let(:logger) { spy('logger') }
 
   before(:each) do


### PR DESCRIPTION
# Logging Interceptor

The logging interceptor logs all requests done with LHC to the Rails logs.

## Installation

```ruby
  LHC.config.interceptors = [LHC::Logging]

  LHC::Logging.logger = Rails.logger  
```

## What and how it logs

The logging Interceptor logs basic information about the request and the response:

```ruby
LHC.get('http://local.ch')
# Before LHC request<70128730317500> GET http://local.ch at 2018-05-23T07:53:19+02:00 Params={} Headers={\"User-Agent\"=>\"Typhoeus - https://github.com/typhoeus/typhoeus\", \"Expect\"=>\"\"}
# After LHC response for request<70128730317500>: GET http://local.ch at 2018-05-23T07:53:28+02:00 Time=0ms URL=http://local.ch:80/
```

## Configure

You can configure the logger beeing used by the logging interceptor:

```ruby
LHC::Logging.logger = Another::Logger
```
