### PR TITLE
Reference list/dir of core interceptors rather than listing every single one

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,17 +259,11 @@ To monitor and manipulate the http communication done with LHC, you can define i
 
 → [Read more about interceptors](docs/interceptors.md)
 
-A set of core interceptors is part of LHC,
-like
-[Caching](/docs/interceptors/caching.md),
-[Monitoring](/docs/interceptors/monitoring.md),
-[Authentication](/docs/interceptors/authentication.md),
-[Retry](/docs/interceptors/retry.md),
-[Rollbar](/docs/interceptors/rollbar.md),
-[Prometheus](/docs/interceptors/prometheus.md).
+### Core Interceptors
 
-→ [Read more about core interceptors](docs/interceptors.md#core-interceptors)
+There are some interceptors that are part of LHC already, that cover some basic usecases:
 
+[Available Core Interceptors](/docs/interceptors)
 
 ## License
 

--- a/docs/interceptors.md
+++ b/docs/interceptors.md
@@ -23,7 +23,8 @@ Interceptors
 ## Core Interceptors
 
 There are some interceptors that are part of LHC already, that cover some basic usecases:
-like [Caching](/docs/interceptors/caching.md), [Monitoring](/docs/interceptors/monitoring.md), [Authentication](/docs/interceptors/authentication.md), [Rollbar](/docs/interceptors/rollbar.md), [Zipkin](/docs/interceptors/zipkin.md).
+
+[Available Core Interceptors](/docs/interceptors)
 
 ## Callbacks
 


### PR DESCRIPTION
This PR links documentation to the directory containing all core interceptor documentations, rather that listing them in various places. Should improve maintainability of the docs.