### PR TITLE
Configurable monitoring ENV

### DIFF
--- a/docs/interceptors/monitoring.md
+++ b/docs/interceptors/monitoring.md
@@ -14,6 +14,14 @@ You also have to configure statsd in order to have the monitoring interceptor re
   LHC::Monitoring.statsd = <your-instance-of-statsd>
 ```
 
+### Environment
+
+By default, the monitoring interceptor uses Rails.env to determine the environment. In case you want to configure that, use:
+
+```ruby
+LHC::Monitoring.env = ENV['DEPLOYMENT_TYPE'] || Rails.env
+```
+
 ## What it tracks
 
 It tracks request attempts with `before_request` and `after_request` (counts).

--- a/lib/lhc/interceptors/monitoring.rb
+++ b/lib/lhc/interceptors/monitoring.rb
@@ -7,7 +7,7 @@ class LHC::Monitoring < LHC::Interceptor
 
   include ActiveSupport::Configurable
 
-  config_accessor :statsd
+  config_accessor :statsd, :env
 
   def before_request
     return unless statsd
@@ -39,7 +39,7 @@ class LHC::Monitoring < LHC::Interceptor
     key = [
       'lhc',
       Rails.application.class.parent_name.underscore,
-      Rails.env,
+      LHC::Monitoring.env || Rails.env,
       URI.parse(url).host.gsub(/\./, '_'),
       request.method
     ]

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION ||= '9.3.1'
+  VERSION ||= '9.4.0'
 end

--- a/spec/interceptors/monitoring/main_spec.rb
+++ b/spec/interceptors/monitoring/main_spec.rb
@@ -77,4 +77,19 @@ describe LHC::Monitoring do
       LHC.get(:local)
     end
   end
+
+  context 'with configured environment' do
+    before do
+      LHC::Monitoring.env = 'beta'
+    end
+
+    it 'uses the configured env' do
+      stub
+      expect(Statsd).to receive(:count).with('lhc.dummy.beta.local_ch.get.before_request', 1)
+      expect(Statsd).to receive(:count).with('lhc.dummy.beta.local_ch.get.after_request', 1)
+      expect(Statsd).to receive(:count).with('lhc.dummy.beta.local_ch.get.count', 1)
+      expect(Statsd).to receive(:count).with('lhc.dummy.beta.local_ch.get.200', 1)
+      LHC.get(:local)
+    end
+  end
 end


### PR DESCRIPTION
The monitoring interceptor was using `Rails.env` to determine the environment it is reporting for to Statsd.

In deployed environments like Kubernetes, where we use Rails.env production for dev/beta/production, but use ENV[`DEPLOYMENT_TYPE`] to define the final environment, the monitoring interceptor needs to be configurable in regards of the `env` it uses for reporting.