### PR TITLE
Do not encode json formatted body twice

### DIFF
--- a/lib/lhc/formats/json.rb
+++ b/lib/lhc/formats/json.rb
@@ -19,7 +19,11 @@ module LHC::Formats
     end
 
     def to_body(input)
-      input.to_json
+      if input.is_a?(Hash)
+        input.to_json
+      else
+        input
+      end
     end
 
     def to_s

--- a/lib/lhc/formats/json.rb
+++ b/lib/lhc/formats/json.rb
@@ -19,10 +19,10 @@ module LHC::Formats
     end
 
     def to_body(input)
-      if input.is_a?(Hash)
-        input.to_json
-      else
+      if input.is_a?(String)
         input
+      else
+        input.to_json
       end
     end
 

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -109,7 +109,7 @@ class LHC::Request
   def generate_url_from_template!
     endpoint = LHC::Endpoint.new(options[:url])
     params =
-      if format && options[:body]&.length
+      if format && options[:body]&.length && options[:body].is_a?(Hash)
         options[:body].merge(options[:params] || {}).deep_symbolize_keys
       else
         options[:params]

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION ||= '9.4.2'
+  VERSION ||= '9.4.3'
 end

--- a/spec/request/body_spec.rb
+++ b/spec/request/body_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe LHC::Request do
+  context 'encode body' do
+    let(:data) { { name: 'Steve' } }
+    let(:encoded_data) { data.to_json }
+
+    before do
+      stub_request(:post, "http://datastore/q")
+        .with(body: encoded_data)
+        .to_return(status: 200)
+    end
+
+    it 'encodes the request body to the given format' do
+      LHC.post('http://datastore/q', body: data)
+    end
+
+    it 'does not encode the request body if it is already a string' do
+      LHC.post('http://datastore/q', body: encoded_data)
+    end
+  end
+end

--- a/spec/request/body_spec.rb
+++ b/spec/request/body_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe LHC::Request do
   context 'encode body' do
-    let(:data) { { name: 'Steve' } }
     let(:encoded_data) { data.to_json }
 
     before do
@@ -11,12 +10,28 @@ describe LHC::Request do
         .to_return(status: 200)
     end
 
-    it 'encodes the request body to the given format' do
-      LHC.post('http://datastore/q', body: data)
+    context 'hash' do
+      let(:data) { { name: 'Steve' } }
+
+      it 'encodes the request body to the given format' do
+        LHC.post('http://datastore/q', body: data)
+      end
+
+      it 'does not encode the request body if it is already a string' do
+        LHC.post('http://datastore/q', body: encoded_data)
+      end
     end
 
-    it 'does not encode the request body if it is already a string' do
-      LHC.post('http://datastore/q', body: encoded_data)
+    context 'array' do
+      let(:data) { [{ name: 'Steve' }] }
+
+      it 'encodes the request body to the given format' do
+        LHC.post('http://datastore/q', body: data)
+      end
+
+      it 'does not encode the request body if it is already a string' do
+        LHC.post('http://datastore/q', body: encoded_data)
+      end
     end
   end
 end


### PR DESCRIPTION
_PATCH_

LHC was trying to encode a given body in it's default format (JSON), even though it might have been already decoded.

This PR patches the previous behaviour. When a body, using the JSON format, is already encoded (a string), it does not encode it (again).