### PR TITLE
Fix require `lhc/version`

### DIFF
--- a/lib/lhc/concerns/lhc/request/user_agent_concern.rb
+++ b/lib/lhc/concerns/lhc/request/user_agent_concern.rb
@@ -1,4 +1,5 @@
 require 'active_support'
+require 'lhc/version'
 
 module LHC
   class Request

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION ||= '10.0.0'
+  VERSION ||= '10.0.1'
 end


### PR DESCRIPTION
In real life, LHC was raising an exception when it was trying to access the VERSION constant for the `User-Agent` header. Unfortunately that was not reproducible with tests.