### PR TITLE
Do not assume hashes when trying to get data from body

### DIFF
--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -111,7 +111,7 @@ class LHC::Request
   def generate_url_from_template!
     endpoint = LHC::Endpoint.new(options[:url])
     params =
-      if format && options[:body].present? && options[:body].respond_to?(:as_json)
+      if format && options[:body].present? && options[:body].respond_to?(:as_json) && options[:body].as_json.is_a?(Hash)
         options[:body].as_json.merge(options[:params] || {}).deep_symbolize_keys
       else
         options[:params]

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -111,8 +111,8 @@ class LHC::Request
   def generate_url_from_template!
     endpoint = LHC::Endpoint.new(options[:url])
     params =
-      if format && options[:body]&.length && options[:body].is_a?(Hash)
-        options[:body].merge(options[:params] || {}).deep_symbolize_keys
+      if format && options[:body].present? && options[:body].respond_to?(:as_json)
+        options[:body].as_json.merge(options[:params] || {}).deep_symbolize_keys
       else
         options[:params]
       end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION ||= '10.0.1'
+  VERSION ||= '10.0.2'
 end

--- a/spec/request/url_patterns_spec.rb
+++ b/spec/request/url_patterns_spec.rb
@@ -20,4 +20,33 @@ describe LHC::Request do
     stub_request(:post, "http://datastore:8080/v2/places/123")
     LHC.json.post('http://datastore:8080/v2/places/{id}', body: { id: 123 })
   end
+
+  context 'custom data structures that respond to as_json (like LHS data or record)' do
+    before do
+      class CustomStructure
+
+        def initialize(data)
+          @data = data
+        end
+
+        def as_json
+          @data.as_json
+        end
+
+        def to_json
+          as_json.to_json
+        end
+      end
+    end
+
+    let(:data) do
+      CustomStructure.new(id: '12345')
+    end
+
+    it 'compiles url from body params when body object respond_to(:as_json)' do
+      stub_request(:post, "http://datastore/places/12345")
+        .to_return(status: 200)
+      LHC.post('http://datastore/places/{id}', body: data)
+    end
+  end
 end


### PR DESCRIPTION
_Targeting 10.0.2_
_Backport as 9.4.4_

In https://github.com/local-ch/lhc/releases/tag/v9.4.3 I introduced the assumption, that the passed body is always a Hash.

Turns out LHS passes LHS::Data and LHS::Record down to LHC as bodies.

This PR fixes the compatibility to LHS and allows custom structures to be passed, as long as they respond to `as_json`.