### PR TITLE
Raise exception if passing headers to formatted requests

### DIFF
--- a/lib/lhc.rb
+++ b/lib/lhc.rb
@@ -113,6 +113,8 @@ module LHC
     'lhc/interceptors'
   autoload :Formats,
     'lhc/formats'
+  autoload :Format,
+    'lhc/format'
   autoload :Monitoring,
     'lhc/interceptors/monitoring'
   autoload :Request,

--- a/lib/lhc/format.rb
+++ b/lib/lhc/format.rb
@@ -1,0 +1,16 @@
+class LHC::Format
+
+  private
+
+  def no_content_type_header!(options)
+    return if (options[:headers].keys & [:'Content-Type', 'Content-Type']).blank?
+
+    raise "Content-Type header is not allowed for formatted requests!"
+  end
+
+  def no_accept_header!(options)
+    return if (options[:headers].keys & [:Accept, 'Accept']).blank?
+
+    raise "Accept header is not allowed for formatted requests!"
+  end
+end

--- a/lib/lhc/format.rb
+++ b/lib/lhc/format.rb
@@ -5,12 +5,12 @@ class LHC::Format
   def no_content_type_header!(options)
     return if (options[:headers].keys & [:'Content-Type', 'Content-Type']).blank?
 
-    raise "Content-Type header is not allowed for formatted requests!"
+    raise 'Content-Type header is not allowed for formatted requests!'
   end
 
   def no_accept_header!(options)
     return if (options[:headers].keys & [:Accept, 'Accept']).blank?
 
-    raise "Accept header is not allowed for formatted requests!"
+    raise 'Accept header is not allowed for formatted requests!'
   end
 end

--- a/lib/lhc/formats/json.rb
+++ b/lib/lhc/formats/json.rb
@@ -1,13 +1,19 @@
 module LHC::Formats
-  class JSON
+  class JSON < LHC::Format
     include LHC::BasicMethodsConcern
 
     def self.request(options)
-      options[:headers] ||= {}
-      options[:headers]['Content-Type'] = 'application/json; charset=utf-8'
-      options[:headers]['Accept'] = 'application/json; charset=utf-8'
       options[:format] = new
       super(options)
+    end
+
+    def format_options(options)
+      options[:headers] ||= {}
+      no_content_type_header!(options)
+      options[:headers]['Content-Type'] = 'application/json; charset=utf-8'
+      no_accept_header!(options)
+      options[:headers]['Accept'] = 'application/json; charset=utf-8'
+      options
     end
 
     def as_json(input)

--- a/lib/lhc/formats/multipart.rb
+++ b/lib/lhc/formats/multipart.rb
@@ -1,12 +1,17 @@
 module LHC::Formats
-  class Multipart
+  class Multipart < LHC::Format
     include LHC::BasicMethodsConcern
 
     def self.request(options)
-      options[:headers] ||= {}
-      options[:headers]['Content-Type'] = 'multipart/form-data'
       options[:format] = new
       super(options)
+    end
+
+    def format_options(options)
+      options[:headers] ||= {}
+      no_content_type_header!(options)
+      options[:headers]['Content-Type'] = 'multipart/form-data'
+      options
     end
 
     def as_json(input)

--- a/lib/lhc/formats/plain.rb
+++ b/lib/lhc/formats/plain.rb
@@ -1,10 +1,14 @@
 module LHC::Formats
-  class Plain
+  class Plain < LHC::Format
     include LHC::BasicMethodsConcern
 
     def self.request(options)
       options[:format] = new
       super(options)
+    end
+
+    def format_options(options)
+      options
     end
 
     def as_json(input)

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -14,9 +14,8 @@ class LHC::Request
 
   def initialize(options, self_executing = true)
     self.errors_ignored = options.fetch(:ignored_errors, [])
-    self.options = options.deep_dup || {}
+    self.options = format!(options.deep_dup || {})
     self.error_handler = options.delete :error_handler
-    self.format = options.delete(:format) || LHC::Formats::JSON.new
     use_configured_endpoint!
     generate_url_from_template!
     self.interceptors = LHC::Interceptors.new(self)
@@ -53,6 +52,11 @@ class LHC::Request
   private
 
   attr_accessor :interceptors
+
+  def format!(options)
+    self.format = options.delete(:format) || LHC::Formats::JSON.new
+    format.format_options(options)
+  end
 
   def optionally_encoded_url(options)
     return options[:url] unless options.fetch(:url_encoding, true)

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,3 +1,3 @@
 module LHC
-  VERSION ||= '10.1.0'
+  VERSION ||= '10.1.1'
 end

--- a/spec/basic_methods/request_without_rails_spec.rb
+++ b/spec/basic_methods/request_without_rails_spec.rb
@@ -19,8 +19,7 @@ describe LHC do
       options = {
         url: "http://datastore/v2/feedbacks",
         method: :post,
-        body: {},
-        headers: { 'Content-Type' => 'application/json' }
+        body: {}
       }
       expect { LHC.request(options) }.not_to raise_error
     end

--- a/spec/formats/json_spec.rb
+++ b/spec/formats/json_spec.rb
@@ -8,5 +8,53 @@ describe LHC do
         .to_return(body: {}.to_json)
       LHC.json.get('http://local.ch')
     end
+
+    context 'header key as symbol' do
+      it 'raises an error when trying to set content-type header even though the format is used' do
+        expect(lambda {
+          LHC.post(
+            'http://local.ch',
+            headers: {
+              'Content-Type': 'multipart/form-data'
+            }
+          )
+        }).to raise_error 'Content-Type header is not allowed for formatted requests!'
+      end
+
+      it 'raises an error when trying to set accept header even though the format is used' do
+        expect(lambda {
+          LHC.post(
+            'http://local.ch',
+            headers: {
+              'Accept': 'multipart/form-data'
+            }
+          )
+        }).to raise_error 'Accept header is not allowed for formatted requests!'
+      end
+    end
+
+    context 'header key as string' do
+      it 'raises an error when trying to set content-type header even though the format is used' do
+        expect(lambda {
+          LHC.post(
+            'http://local.ch',
+            headers: {
+              'Content-Type' => 'multipart/form-data'
+            }
+          )
+        }).to raise_error 'Content-Type header is not allowed for formatted requests!'
+      end
+
+      it 'raises an error when trying to set accept header even though the format is used' do
+        expect(lambda {
+          LHC.post(
+            'http://local.ch',
+            headers: {
+              'Accept' => 'multipart/form-data'
+            }
+          )
+        }).to raise_error 'Accept header is not allowed for formatted requests!'
+      end
+    end
   end
 end


### PR DESCRIPTION
_PATCH_
Will back port to 10.0.1, too.

This PR introduces exceptions when LHC is asked to set the "Content-Type" or "Accept" (in case of json), when the request is already formatted!