### PR TITLE
Improve json format

### DIFF
--- a/lib/lhc/error.rb
+++ b/lib/lhc/error.rb
@@ -59,7 +59,8 @@ class LHC::Error < StandardError
     request = response.request
     debug = []
     debug << [request.method, request.url].map { |str| fix_invalid_encoding(str) }.join(' ')
-    debug << "Options: #{request.options}"
+    debug << "Options: #{request.options.except(:interceptors).to_json}"
+    debug << "Interceptors: #{request.options[:interceptors]}"
     debug << "Headers: #{request.headers.to_json}"
     debug << "Response Code: #{response.code} (#{response.options[:return_code]})"
     debug << "Repsonse Options: #{response.options}"

--- a/lib/lhc/error.rb
+++ b/lib/lhc/error.rb
@@ -59,8 +59,8 @@ class LHC::Error < StandardError
     request = response.request
     debug = []
     debug << [request.method, request.url].map { |str| fix_invalid_encoding(str) }.join(' ')
-    debug << "Options: #{request.options}"
-    debug << "Headers: #{request.headers}"
+    debug << "Options: #{request.options.to_json}"
+    debug << "Headers: #{request.headers.to_json}"
     debug << "Response Code: #{response.code} (#{response.options[:return_code]})"
     debug << "Repsonse Options: #{response.options}"
     debug << response.body

--- a/lib/lhc/error.rb
+++ b/lib/lhc/error.rb
@@ -59,7 +59,7 @@ class LHC::Error < StandardError
     request = response.request
     debug = []
     debug << [request.method, request.url].map { |str| fix_invalid_encoding(str) }.join(' ')
-    debug << "Options: #{request.options.except(:interceptors).to_json}"
+    debug << "Options: #{request.options.except(:interceptors, :key).to_json}"
     debug << "Interceptors: #{request.options[:interceptors]}"
     debug << "Headers: #{request.headers.to_json}"
     debug << "Response Code: #{response.code} (#{response.options[:return_code]})"

--- a/lib/lhc/error.rb
+++ b/lib/lhc/error.rb
@@ -59,7 +59,7 @@ class LHC::Error < StandardError
     request = response.request
     debug = []
     debug << [request.method, request.url].map { |str| fix_invalid_encoding(str) }.join(' ')
-    debug << "Options: #{request.options.to_json}"
+    debug << "Options: #{request.options}"
     debug << "Headers: #{request.headers.to_json}"
     debug << "Response Code: #{response.code} (#{response.options[:return_code]})"
     debug << "Repsonse Options: #{response.options}"

--- a/lib/lhc/interceptors/logging.rb
+++ b/lib/lhc/interceptors/logging.rb
@@ -6,7 +6,7 @@ class LHC::Logging < LHC::Interceptor
   def before_request
     return unless logger
     logger.info(
-      "Before LHC request<#{request.object_id}> #{request.method.upcase} #{request.url} at #{Time.now.iso8601} Params=#{request.params} Headers=#{request.headers}"
+      "Before LHC request<#{request.object_id}> #{request.method.upcase} #{request.url} at #{Time.now.iso8601} Params=#{request.params.to_json} Headers=#{request.headers.to_json}"
     )
   end
 

--- a/spec/error/to_s_spec.rb
+++ b/spec/error/to_s_spec.rb
@@ -49,6 +49,7 @@ describe LHC::Error do
                headers: { 'Bearer Token' => "aaaaaaaa-bbbb-cccc-dddd-eeee" },
                options: { followlocation: true,
                           auth: { bearer: "aaaaaaaa-bbbb-cccc-dddd-eeee" },
+                          interceptors: [LHC::Auth],
                           params: { limit: 20 }, url: "http://example.com/sessions" })
       end
 
@@ -66,6 +67,7 @@ describe LHC::Error do
         expect(subject.to_s.split("\n")).to eq(<<-MSG.strip_heredoc.split("\n"))
           GET http://example.com/sessions
           Options: {"followlocation":true,"auth":{"bearer":"aaaaaaaa-bbbb-cccc-dddd-eeee"},"params":{"limit":20},"url":"http://example.com/sessions"}
+          Interceptors: [LHC::Auth]
           Headers: {"Bearer Token":"aaaaaaaa-bbbb-cccc-dddd-eeee"}
           Response Code: 500 (internal_error)
           Repsonse Options: {:return_code=>:internal_error, :response_headers=>""}

--- a/spec/error/to_s_spec.rb
+++ b/spec/error/to_s_spec.rb
@@ -65,8 +65,8 @@ describe LHC::Error do
       it 'produces correct debug output' do
         expect(subject.to_s.split("\n")).to eq(<<-MSG.strip_heredoc.split("\n"))
           GET http://example.com/sessions
-          Options: {:followlocation=>true, :auth=>{:bearer=>"aaaaaaaa-bbbb-cccc-dddd-eeee"}, :params=>{:limit=>20}, :url=>"http://example.com/sessions"}
-          Headers: {"Bearer Token"=>"aaaaaaaa-bbbb-cccc-dddd-eeee"}
+          Options: {"followlocation":true,"auth":{"bearer":"aaaaaaaa-bbbb-cccc-dddd-eeee"},"params":{"limit":20},"url":"http://example.com/sessions"}
+          Headers: {"Bearer Token":"aaaaaaaa-bbbb-cccc-dddd-eeee"}
           Response Code: 500 (internal_error)
           Repsonse Options: {:return_code=>:internal_error, :response_headers=>""}
           {"status":500,"message":"undefined"}


### PR DESCRIPTION
_MINOR_

This PR improves the log-ouput for json-data:

**Before:**

```
Before LHC request<70204499078600> GET http://server.ch/******* at 2018-11-14T17:45:19+01:00 Params={} Headers={"User-Agent"=>"LHC (10.0.2; *******) [https://github.com/local-ch/lhc]", "Authorization"=>"Bearer *******", "Expect"=>""}
```

**After:**

```
Before LHC request<70117149524060> GET http://server.ch/******* at 2018-11-14T17:45:19+01:00 Params={} Headers={"User-Agent":"LHC (10.0.2; *******) [https://github.com/local-ch/lhc]","Authorization":"Bearer *******","Expect":""}
```

**Reason:**

Especially for errors as a developer you might want to copy the failing request and debug it in Postman or similar tools. With the JSON-Syntax this is much easier.