### PR TITLE
Increase verbosity of format errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ LHC.json.get(options)
 
 Currently supported formats: `json`, `multipart`, `plain` (for no formatting)
 
-If formats are used, headers for `Content-Type` and `Accept` are set by LHC, but also http bodies are translated by LHC, so you can pass bodies as ruby objects:
+If formats are used, headers for `Content-Type` and `Accept` are enforced by LHC, but also http bodies are translated by LHC, so you can pass bodies as ruby objects:
 
 ```ruby
 LHC.json.post('http://slack', body: { text: 'Hi there' })

--- a/lib/lhc/format.rb
+++ b/lib/lhc/format.rb
@@ -7,12 +7,12 @@ class LHC::Format
   def no_content_type_header!(options)
     return if (options[:headers].keys & [:'Content-Type', 'Content-Type']).blank?
 
-    raise 'Content-Type header is not allowed for formatted requests!'
+    raise 'Content-Type header is not allowed for formatted requests! Use plain requests instead.'
   end
 
   def no_accept_header!(options)
     return if (options[:headers].keys & [:Accept, 'Accept']).blank?
 
-    raise 'Accept header is not allowed for formatted requests!'
+    raise 'Accept header is not allowed for formatted requests! Use plain requests instead.'
   end
 end

--- a/lib/lhc/format.rb
+++ b/lib/lhc/format.rb
@@ -7,12 +7,12 @@ class LHC::Format
   def no_content_type_header!(options)
     return if (options[:headers].keys & [:'Content-Type', 'Content-Type']).blank?
 
-    raise 'Content-Type header is not allowed for formatted requests! Use plain requests instead.'
+    raise 'Content-Type header is not allowed for formatted requests!\nSee https://github.com/local-ch/lhc#formats for more information.'
   end
 
   def no_accept_header!(options)
     return if (options[:headers].keys & [:Accept, 'Accept']).blank?
 
-    raise 'Accept header is not allowed for formatted requests! Use plain requests instead.'
+    raise 'Accept header is not allowed for formatted requests!\nSee https://github.com/local-ch/lhc#formats for more information.'
   end
 end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '10.1.3'
+  VERSION ||= '10.1.4'
 end

--- a/spec/formats/json_spec.rb
+++ b/spec/formats/json_spec.rb
@@ -20,7 +20,7 @@ describe LHC do
               'Content-Type': 'multipart/form-data'
             }
           )
-        }).to raise_error 'Content-Type header is not allowed for formatted requests!'
+        }).to raise_error 'Content-Type header is not allowed for formatted requests!\nSee https://github.com/local-ch/lhc#formats for more information.'
       end
 
       it 'raises an error when trying to set accept header even though the format is used' do
@@ -31,7 +31,7 @@ describe LHC do
               'Accept': 'multipart/form-data'
             }
           )
-        }).to raise_error 'Accept header is not allowed for formatted requests!'
+        }).to raise_error 'Accept header is not allowed for formatted requests!\nSee https://github.com/local-ch/lhc#formats for more information.'
       end
     end
 
@@ -44,7 +44,7 @@ describe LHC do
               'Content-Type' => 'multipart/form-data'
             }
           )
-        }).to raise_error 'Content-Type header is not allowed for formatted requests!'
+        }).to raise_error 'Content-Type header is not allowed for formatted requests!\nSee https://github.com/local-ch/lhc#formats for more information.'
       end
 
       it 'raises an error when trying to set accept header even though the format is used' do
@@ -55,7 +55,7 @@ describe LHC do
               'Accept' => 'multipart/form-data'
             }
           )
-        }).to raise_error 'Accept header is not allowed for formatted requests!'
+        }).to raise_error 'Accept header is not allowed for formatted requests!\nSee https://github.com/local-ch/lhc#formats for more information.'
       end
     end
   end


### PR DESCRIPTION
Would it make sense to be clearer in the error messages? My proposal is easier to _CTRL+F_.