### PR TITLE
Patch Zipkin

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,6 +838,8 @@ If it raises, it forwards the request and response object to rollbar, which cont
 
 #### Zipkin
 
+** Zipkin 0.33 breaks our current implementation of the Zipkin interceptor **
+
 Zipkin is a distributed tracing system. It helps gather timing data needed to troubleshoot latency problems in microservice architectures [Zipkin Distributed Tracing](https://zipkin.io/).
 
 Add the zipkin interceptor to your basic set of LHC interceptors.
@@ -850,7 +852,7 @@ Add the zipkin interceptor to your basic set of LHC interceptors.
 
 The following configuration needs to happen in the application that wants to run this interceptor:
 
-1. Add `gem 'zipkin-tracer'` to your Gemfile.
+1. Add `gem 'zipkin-tracer', '< 0.33.0'` to your Gemfile.
 2. Add the necessary Rack middleware and configuration
 
 ```ruby

--- a/lib/lhc/interceptors/zipkin.rb
+++ b/lib/lhc/interceptors/zipkin.rb
@@ -98,7 +98,10 @@ class LHC::Zipkin < LHC::Interceptor
     (
       defined?(ZipkinTracer::TraceContainer) &&
       ZipkinTracer::TraceContainer.current &&
-      defined?(Trace)
+      defined?(::Trace) &&
+      defined?(::Trace::Annotation) &&
+      defined?(::Trace::BinaryAnnotation) &&
+      defined?(::Trace::Endpoint)
     ) || warn('[WARNING] Zipkin interceptor is enabled but dependencies are not found. See: https://github.com/local-ch/lhc/blob/master/docs/interceptors/zipkin.md')
   end
 end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '10.1.4'
+  VERSION ||= '10.1.5'
 end


### PR DESCRIPTION
Onboarding uses latest `zipkin-tracer` which (even though it was a minor upgrade) introduces breaking changes.

https://rollbar.com/local.ch/onboarding/items/423/
<img width="1245" alt="Screen Shot 2019-03-21 at 11 35 12 AM" src="https://user-images.githubusercontent.com/851393/54746845-84ce4400-4bcd-11e9-87d7-911974e74295.png">

This PR adds more checks for ZipkinTracer internals to not trace if they are not around.