### PR TITLE
Update Charset and Content-Type Headers

### DIFF
--- a/lhc.gemspec
+++ b/lhc.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'geminabox'
   s.add_development_dependency 'prometheus-client', '~> 0.7.1'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'rails', '~> 4.2'
+  s.add_development_dependency 'rails', '>= 4.2'
   s.add_development_dependency 'rspec-rails', '>= 3.0.0'
   s.add_development_dependency 'rubocop', '~> 0.57.1'
   s.add_development_dependency 'rubocop-rspec', '~> 1.26.0'

--- a/lib/lhc/formats/json.rb
+++ b/lib/lhc/formats/json.rb
@@ -12,9 +12,10 @@ module LHC::Formats
     def format_options(options)
       options[:headers] ||= {}
       no_content_type_header!(options)
-      options[:headers]['Content-Type'] = 'application/json; charset=utf-8'
       no_accept_header!(options)
-      options[:headers]['Accept'] = 'application/json'
+
+      options[:headers]['Content-Type'] = 'application/json; charset=utf-8'
+      options[:headers]['Accept'] = 'application/json,application/vnd.api+json'
       options[:headers]['Accept-Charset'] = 'utf-8'
       options
     end

--- a/lib/lhc/formats/json.rb
+++ b/lib/lhc/formats/json.rb
@@ -14,7 +14,8 @@ module LHC::Formats
       no_content_type_header!(options)
       options[:headers]['Content-Type'] = 'application/json; charset=utf-8'
       no_accept_header!(options)
-      options[:headers]['Accept'] = 'application/json; charset=utf-8'
+      options[:headers]['Accept'] = 'application/json'
+      options[:headers]['Accept-Charset'] = 'utf-8'
       options
     end
 

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '10.1.6'
+  VERSION ||= '10.1.7'
 end

--- a/spec/formats/json_spec.rb
+++ b/spec/formats/json_spec.rb
@@ -4,9 +4,13 @@ require 'rails_helper'
 
 describe LHC do
   context 'formats' do
-    it 'adds Content-Type and Accept Headers to the request' do
+    it 'adds Content-Type, Accept and Accept-Charset Headers to the request' do
       stub_request(:get, "http://local.ch/")
-        .with(headers: { 'Accept' => 'application/json; charset=utf-8', 'Content-Type' => 'application/json; charset=utf-8' })
+        .with(headers: {
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json; charset=utf-8',
+                'Accept-Charset' => 'utf-8'
+              })
         .to_return(body: {}.to_json)
       LHC.json.get('http://local.ch')
     end

--- a/spec/formats/json_spec.rb
+++ b/spec/formats/json_spec.rb
@@ -7,7 +7,7 @@ describe LHC do
     it 'adds Content-Type, Accept and Accept-Charset Headers to the request' do
       stub_request(:get, "http://local.ch/")
         .with(headers: {
-                'Accept' => 'application/json',
+                'Accept' => 'application/json,application/vnd.api+json',
                 'Content-Type' => 'application/json; charset=utf-8',
                 'Accept-Charset' => 'utf-8'
               })

--- a/spec/response/data_accessor_spec.rb
+++ b/spec/response/data_accessor_spec.rb
@@ -7,10 +7,9 @@ describe LHC do
     before(:each) do
       stub_request(:get, "http://local.ch/")
         .with(headers: {
-                'Accept' => 'application/json',
+                'Accept' => 'application/json,application/vnd.api+json',
                 'Content-Type' => 'application/json; charset=utf-8',
                 'Accept-Charset' => 'utf-8'
-
               })
         .to_return(body: { 'MyProp' => 'MyValue' }.to_json)
     end

--- a/spec/response/data_accessor_spec.rb
+++ b/spec/response/data_accessor_spec.rb
@@ -6,7 +6,12 @@ describe LHC do
   context 'data accessor (hash with indifferent access)' do
     before(:each) do
       stub_request(:get, "http://local.ch/")
-        .with(headers: { 'Accept' => 'application/json; charset=utf-8', 'Content-Type' => 'application/json; charset=utf-8' })
+        .with(headers: {
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json; charset=utf-8',
+                'Accept-Charset' => 'utf-8'
+
+              })
         .to_return(body: { 'MyProp' => 'MyValue' }.to_json)
     end
 


### PR DESCRIPTION
# Changes introduced in this PR:

### Support json:api content-type

json:api is a content-type that some APIs support. It is documented in
great detail here: https://jsonapi.org/

LHC/LHS can handle both content types and can safely state so in the accept
header.

###    Introduce Accept-Charset header

Instead of appending the charset to the accept header, use the dedicated
Accept-Charset header which takes precedence over the appended charset part
in the Accept header.

## TODO
- [ ] Update Version