### PR TITLE
Fix ignored errors with nil

### DIFF
--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -15,7 +15,7 @@ class LHC::Request
   attr_accessor :response, :options, :raw, :format, :error_handler, :errors_ignored
 
   def initialize(options, self_executing = true)
-    self.errors_ignored = options.fetch(:ignored_errors, [])
+    self.errors_ignored = (options.fetch(:ignored_errors, []) || []).compact
     self.options = format!(options.deep_dup || {})
     self.error_handler = options.delete :error_handler
     use_configured_endpoint!

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '10.1.7'
+  VERSION ||= '10.1.8'
 end

--- a/spec/request/ignore_errors_spec.rb
+++ b/spec/request/ignore_errors_spec.rb
@@ -46,4 +46,20 @@ describe LHC::Request do
       }.to raise_error(LHC::NotFound)
     end
   end
+
+  context 'does not raise exception if ignored errors is set to nil' do
+    before { stub_request(:get, 'http://local.ch').to_return(status: 404) }
+
+    it "does not raise an error when ignored errors is set to array with nil" do
+      expect {
+        LHC.get('http://local.ch', ignored_errors: [nil])
+      }.to raise_error(LHC::NotFound)
+    end
+
+    it "does not raise an error when ignored errors is set to array with nil" do
+      expect {
+        LHC.get('http://local.ch', ignored_errors: nil)
+      }.to raise_error(LHC::NotFound)
+    end
+  end
 end

--- a/spec/request/ignore_errors_spec.rb
+++ b/spec/request/ignore_errors_spec.rb
@@ -56,7 +56,7 @@ describe LHC::Request do
       }.to raise_error(LHC::NotFound)
     end
 
-    it "does not raise an error when ignored errors is set to array with nil" do
+    it "does not raise an error when ignored errors is set to nil" do
       expect {
         LHC.get('http://local.ch', ignored_errors: nil)
       }.to raise_error(LHC::NotFound)


### PR DESCRIPTION
_PATCH_

Fixes the cases where ignore errors was called with `[nil]` `nil` from LHS.

Does not fail now, just ignores those params.