### PR TITLE
Avoid zipkin warnings in test and dev

### DIFF
--- a/lib/lhc/interceptors/zipkin.rb
+++ b/lib/lhc/interceptors/zipkin.rb
@@ -11,7 +11,7 @@ class LHC::Zipkin < LHC::Interceptor
   TRUE = '1' # true in binary annotation
 
   def before_request
-    return unless dependencies? || tracing?
+    return if !dependencies? || !tracing?
     ZipkinTracer::TraceContainer.with_trace_id(trace_id) do
       # add headers even if the current trace_id should not be sampled
       B3_HEADERS.each { |method, header| request.headers[header] = trace_id.send(method).to_s }

--- a/lib/lhc/interceptors/zipkin.rb
+++ b/lib/lhc/interceptors/zipkin.rb
@@ -11,7 +11,7 @@ class LHC::Zipkin < LHC::Interceptor
   TRUE = '1' # true in binary annotation
 
   def before_request
-    return unless dependencies?
+    return unless dependencies? || tracing?
     ZipkinTracer::TraceContainer.with_trace_id(trace_id) do
       # add headers even if the current trace_id should not be sampled
       B3_HEADERS.each { |method, header| request.headers[header] = trace_id.send(method).to_s }
@@ -27,6 +27,10 @@ class LHC::Zipkin < LHC::Interceptor
   end
 
   private
+
+  def tracing?
+    ZipkinTracer::TraceContainer.current
+  end
 
   def start_trace!
     record_path
@@ -97,7 +101,6 @@ class LHC::Zipkin < LHC::Interceptor
   def dependencies?
     (
       defined?(ZipkinTracer::TraceContainer) &&
-      ZipkinTracer::TraceContainer.current &&
       defined?(::Trace) &&
       defined?(::Trace::Annotation) &&
       defined?(::Trace::BinaryAnnotation) &&

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '10.2.0'
+  VERSION ||= '10.2.1'
 end


### PR DESCRIPTION
We get the following warnings a lot (unnecessarily)
```
[WARNING] Zipkin interceptor is enabled but dependencies are not found. See: https://github.com/local-ch/lhc#zipkin
```

This PR decouples `tracing?` (if tracing is happening) from `dependencies?` (which clearly just checks for dependencies.

So in your tests it would still complain if Zipkin has wrong dependencies (which might make your app crash when deployed), but it's not flooding you with warnings any longer, just because there is no current trace!