### PR TITLE
Throttle interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,7 +847,7 @@ If it raises, it forwards the request and response object to rollbar, which cont
 
 #### Throttle
 
-The throttle interceptor allows you to raise an exception if a predefined quota of an provider request limit is reached in advance.
+The throttle interceptor allows you to raise an exception if a predefined quota of a provider request limit is reached in advance.
 
 ```ruby
   LHC.configure do |c|

--- a/README.md
+++ b/README.md
@@ -858,7 +858,7 @@ The throttle interceptor allows you to raise an exception if a predefined quota 
 options = { 
   throttle: {
     track: true, # enables tracking of current limit/remaining requests of rate-limiting
-    break: '80%', # quota in percent after which errors are raised
+    break: '80%', # quota in percent after which errors are raised. Percentage symbol is optional, values will be converted to integer (e.g. '23.5' will become 23)
     provider: 'local.ch', # name of the provider under which throttling tracking is aggregated,
     limit: { header: 'Rate-Limit-Limit' }, # either a hard-coded integer, or a hash pointing at the response header containing the limit value
     remaining: { header: 'Rate-Limit-Remaining' }, # a hash pointing at the response header containing the current amount of remaining requests

--- a/README.md
+++ b/README.md
@@ -845,6 +845,33 @@ If it raises, it forwards the request and response object to rollbar, which cont
   LHC.get('http://local.ch', rollbar: { tracking_key: 'this particular request' })
 ```
 
+#### Throttle
+
+The throttle interceptor allows you to raise an exception if a predefined quota of an provider request limit is reached in advance.
+
+```ruby
+  LHC.configure do |c|
+    c.interceptors = [LHC::LHC::Throttle]
+  end
+```
+```ruby
+options = { 
+  throttle: {
+    track: true, # enables tracking of current limit/remaining requests of rate-limiting
+    break: '80%', # quota in percent after which errors are raised
+    provider: 'local.ch', # name of the provider under which throttling tracking is aggregated,
+    limit: { header: 'Rate-Limit-Limit' }, # either a hard-coded integer, or a hash pointing at the response header containing the limit value
+    remaining: { header: 'Rate-Limit-Remaining' }, # a hash pointing at the response header containing the current amount of remaining requests
+  } 
+}
+
+LHC.get('http://local.ch', options)
+# { headers: { 'Rate-Limit-Limit' => 100, 'Rate-Limit-Remaining' => 19 } }
+
+LHC.get('http://local.ch', options)
+# raises LHC::Throttle::OutOfQuota: Reached predefined quota for local.ch
+```
+
 #### Zipkin
 
 ** Zipkin 0.33 breaks our current implementation of the Zipkin interceptor **

--- a/README.md
+++ b/README.md
@@ -851,7 +851,7 @@ The throttle interceptor allows you to raise an exception if a predefined quota 
 
 ```ruby
   LHC.configure do |c|
-    c.interceptors = [LHC::LHC::Throttle]
+    c.interceptors = [LHC::Throttle]
   end
 ```
 ```ruby

--- a/friday.yml
+++ b/friday.yml
@@ -1,0 +1,3 @@
+---
+  request_reviews: true
+  cleanup_stale_branches: 8.days

--- a/lib/lhc.rb
+++ b/lib/lhc.rb
@@ -28,6 +28,8 @@ module LHC
     'lhc/interceptors/prometheus'
   autoload :Retry,
     'lhc/interceptors/retry'
+  autoload :Throttle,
+    'lhc/interceptors/throttle'
 
   autoload :Config,
     'lhc/config'

--- a/lib/lhc/interceptors/throttle.rb
+++ b/lib/lhc/interceptors/throttle.rb
@@ -38,7 +38,7 @@ class LHC::Throttle < LHC::Interceptor
     remaining = track[:remaining] * 100
     limit = track[:limit]
     quota = 100 - options[:break].to_i
-    raise(OutOfQuota, "Reached predefined quota for #{options[:provider]}") if remaining / limit < quota
+    raise(OutOfQuota, "Reached predefined quota for #{options[:provider]}") if remaining < quota * limit
   end
 
   def limit(options:, response:)

--- a/lib/lhc/interceptors/throttle.rb
+++ b/lib/lhc/interceptors/throttle.rb
@@ -38,7 +38,7 @@ class LHC::Throttle < LHC::Interceptor
     remaining = track[:remaining] * 100
     limit = track[:limit]
     quota = 100 - options[:break].to_i
-    raise OutOfQuota.new("Reached predefined quota for #{options[:provider]}") if remaining / limit < quota
+    raise(OutOfQuota, "Reached predefined quota for #{options[:provider]}") if remaining / limit < quota
   end
 
   def limit(options:, response:)

--- a/lib/lhc/interceptors/throttle.rb
+++ b/lib/lhc/interceptors/throttle.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class LHC::Throttle < LHC::Interceptor
+
+  class OutOfQuota < StandardError
+  end
+
+  class << self
+    attr_accessor :track
+  end
+
+  def before_request
+    options = request.options.dig(:throttle)
+    return unless options
+    break_options = options.dig(:break)
+    return unless break_options
+    break_when_quota_reached! if break_options.match('%')
+  end
+
+  def after_response
+    options = response.request.options.dig(:throttle)
+    return unless options
+    return unless options.dig(:track)
+    self.class.track ||= {}
+    self.class.track[options.dig(:provider)] = {
+      limit: limit(options: options[:limit], response: response),
+      remaining: remaining(options: options[:remaining], response: response)
+    }
+  end
+
+  private
+
+  def break_when_quota_reached!
+    options = request.options.dig(:throttle)
+    track = (self.class.track || {}).dig(options[:provider])
+    return unless track
+    # avoid floats by multiplying with 100
+    remaining = track[:remaining] * 100
+    limit = track[:limit]
+    quota = 100 - options[:break].to_i
+    raise OutOfQuota.new("Reached predefined quota for #{options[:provider]}") if remaining / limit < quota
+  end
+
+  def limit(options:, response:)
+    @limit ||= begin
+      if options.is_a?(Integer)
+        options
+      elsif options.is_a?(Hash) && options[:header]
+        response.headers[options[:header]]&.to_i
+      end
+    end
+  end
+
+  def remaining(options:, response:)
+    @remaining ||= begin
+      if options.is_a?(Hash) && options[:header]
+        response.headers[options[:header]]&.to_i
+      end
+    end
+  end
+end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '10.3.0'
+  VERSION ||= '10.4.0'
 end

--- a/spec/interceptors/throttle/main_spec.rb
+++ b/spec/interceptors/throttle/main_spec.rb
@@ -25,10 +25,12 @@ describe LHC::Throttle do
     LHC.config.interceptors = [LHC::Throttle]
 
     stub_request(:get, 'http://local.ch')
-      .to_return(headers: {
-        'Rate-Limit-Limit' => limit,
-        'Rate-Limit-Remaining' => remaining
-      })
+      .to_return(
+        headers: {
+          'Rate-Limit-Limit' => limit,
+          'Rate-Limit-Remaining' => remaining
+        }
+      )
   end
 
   it 'tracks the request limits based on response data' do

--- a/spec/interceptors/throttle/main_spec.rb
+++ b/spec/interceptors/throttle/main_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LHC::Throttle do
+  let(:provider) { 'local.ch' }
+  let(:limit) { 10000 }
+  let(:remaining) { 1900 }
+  let(:options) do
+    {
+      throttle: {
+        provider: provider,
+        track: true,
+        limit: limit_options,
+        remaining: { header: 'Rate-Limit-Remaining' },
+        break: break_option
+      }
+    }
+  end
+  let(:limit_options) { { header: 'Rate-Limit-Limit' } }
+  let(:break_option) { false }
+
+  before(:each) do
+    LHC::Throttle.track = nil
+    LHC.config.interceptors = [LHC::Throttle]
+
+    stub_request(:get, 'http://local.ch')
+      .to_return(headers: {
+        'Rate-Limit-Limit' => limit,
+        'Rate-Limit-Remaining' => remaining
+      })
+  end
+
+  it 'tracks the request limits based on response data' do
+    LHC.get('http://local.ch', options)
+    expect(LHC::Throttle.track[provider][:limit]).to eq limit
+    expect(LHC::Throttle.track[provider][:remaining]).to eq remaining
+  end
+
+  context 'fix predefined integer for limit' do
+    let(:limit_options) { 1000 }
+
+    it 'tracks the limit based on initialy provided data' do
+      LHC.get('http://local.ch', options)
+      expect(LHC::Throttle.track[provider][:limit]).to eq limit_options
+    end
+  end
+
+  context 'breaks' do
+    let(:break_option) { '80%' }
+
+    it 'hit the breaks if throttling quota is reached' do
+      LHC.get('http://local.ch', options)
+      expect(-> {
+        LHC.get('http://local.ch', options)
+      }).to raise_error(LHC::Throttle::OutOfQuota, 'Reached predefined quota for local.ch')
+    end
+
+    context 'still within quota' do
+      let(:break_option) { '90%' }
+
+      it 'does not hit the breaks' do
+        LHC.get('http://local.ch', options)
+        LHC.get('http://local.ch', options)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces the throttle interceptor.

#### Throttle

The throttle interceptor allows you to raise an exception if a predefined quota of an provider request limit is reached in advance.

```ruby
  LHC.configure do |c|
    c.interceptors = [LHC::Throttle]
  end
```
```ruby
options = { 
  throttle: {
    track: true, # enables tracking of current limit/remaining requests of rate-limiting
    break: '80%', # quota in percent after which errors are raised
    provider: 'local.ch', # name of the provider under which throttling tracking is aggregated,
    limit: { header: 'Rate-Limit-Limit' }, # either a hard-coded integer, or a hash pointing at the response header containing the limit value
    remaining: { header: 'Rate-Limit-Remaining' }, # a hash pointing at the response header containing the current amount of remaining requests
  } 
}

LHC.get('http://local.ch', options)
# { headers: { 'Rate-Limit-Limit' => 100, 'Rate-Limit-Remaining' => 19 } }

LHC.get('http://local.ch', options)
# raises LHC::Throttle::OutOfQuota: Reached predefined quota for local.ch
```