### PR TITLE
Fix accessing none existing headers

### DIFF
--- a/lib/lhc/interceptors/throttle.rb
+++ b/lib/lhc/interceptors/throttle.rb
@@ -45,7 +45,7 @@ class LHC::Throttle < LHC::Interceptor
     @limit ||= begin
       if options.is_a?(Integer)
         options
-      elsif options.is_a?(Hash) && options[:header]
+      elsif options.is_a?(Hash) && options[:header] && response.headers.present?
         response.headers[options[:header]]&.to_i
       end
     end
@@ -53,7 +53,7 @@ class LHC::Throttle < LHC::Interceptor
 
   def remaining(options:, response:)
     @remaining ||= begin
-      if options.is_a?(Hash) && options[:header]
+      if options.is_a?(Hash) && options[:header] && response.headers.present?
         response.headers[options[:header]]&.to_i
       end
     end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '10.4.0'
+  VERSION ||= '10.4.1'
 end

--- a/spec/interceptors/throttle/main_spec.rb
+++ b/spec/interceptors/throttle/main_spec.rb
@@ -71,7 +71,7 @@ describe LHC::Throttle do
   context 'no response headers' do
     before do
       stub_request(:get, 'http://local.ch')
-      .to_return(status: 200)
+        .to_return(status: 200)
     end
 
     it 'does not raise an exception' do

--- a/spec/interceptors/throttle/main_spec.rb
+++ b/spec/interceptors/throttle/main_spec.rb
@@ -67,4 +67,15 @@ describe LHC::Throttle do
       end
     end
   end
+
+  context 'no response headers' do
+    before do
+      stub_request(:get, 'http://local.ch')
+      .to_return(status: 200)
+    end
+
+    it 'does not raise an exception' do
+      LHC.get('http://local.ch', options)
+    end
+  end
 end


### PR DESCRIPTION
Was throwing exception when response had no headers set. Now does not raise any more.