### PR TITLE
Fix case where tacked reamining is nil

### DIFF
--- a/lib/lhc/interceptors/throttle.rb
+++ b/lib/lhc/interceptors/throttle.rb
@@ -33,7 +33,7 @@ class LHC::Throttle < LHC::Interceptor
   def break_when_quota_reached!
     options = request.options.dig(:throttle)
     track = (self.class.track || {}).dig(options[:provider])
-    return unless track
+    return if track.blank? || track[:remaining].blank? || track[:limit].blank?
     # avoid floats by multiplying with 100
     remaining = track[:remaining] * 100
     limit = track[:limit]

--- a/spec/interceptors/throttle/main_spec.rb
+++ b/spec/interceptors/throttle/main_spec.rb
@@ -77,5 +77,14 @@ describe LHC::Throttle do
     it 'does not raise an exception' do
       LHC.get('http://local.ch', options)
     end
+
+    context 'no remaining tracked, but break enabled' do
+      let(:break_option) { '90%' }
+
+      it 'does not fail if a remaining was not tracked yet' do
+        LHC.get('http://local.ch', options)
+        LHC.get('http://local.ch', options)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the case where tracked remaining was nil, and throttling break threw an exception.