### PR TITLE
Throttling expires

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,6 +862,7 @@ options = {
     provider: 'local.ch', # name of the provider under which throttling tracking is aggregated,
     limit: { header: 'Rate-Limit-Limit' }, # either a hard-coded integer, or a hash pointing at the response header containing the limit value
     remaining: { header: 'Rate-Limit-Remaining' }, # a hash pointing at the response header containing the current amount of remaining requests
+    expires: { header: 'Rate-Limit-Reset' } # a hash pointing at the response header containing the timestamp when the quota will reset
   } 
 }
 

--- a/lhc.gemspec
+++ b/lhc.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails', '>= 3.0.0'
   s.add_development_dependency 'rubocop', '~> 0.57.1'
   s.add_development_dependency 'rubocop-rspec', '~> 1.26.0'
+  s.add_development_dependency 'timecop'
   s.add_development_dependency 'webmock'
 
   s.license = 'GPL-3'

--- a/lib/lhc/interceptors/throttle.rb
+++ b/lib/lhc/interceptors/throttle.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support/duration'
+
 class LHC::Throttle < LHC::Interceptor
 
   class OutOfQuota < StandardError
@@ -24,7 +26,8 @@ class LHC::Throttle < LHC::Interceptor
     self.class.track ||= {}
     self.class.track[options.dig(:provider)] = {
       limit: limit(options: options[:limit], response: response),
-      remaining: remaining(options: options[:remaining], response: response)
+      remaining: remaining(options: options[:remaining], response: response),
+      expires: expires(options: options[:expires], response: response)
     }
   end
 
@@ -33,7 +36,8 @@ class LHC::Throttle < LHC::Interceptor
   def break_when_quota_reached!
     options = request.options.dig(:throttle)
     track = (self.class.track || {}).dig(options[:provider])
-    return if track.blank? || track[:remaining].blank? || track[:limit].blank?
+    return if track.blank? || track[:remaining].blank? || track[:limit].blank? || track[:expires].blank?
+    return if Time.zone.now > track[:expires]
     # avoid floats by multiplying with 100
     remaining = track[:remaining] * 100
     limit = track[:limit]
@@ -56,6 +60,26 @@ class LHC::Throttle < LHC::Interceptor
       if options.is_a?(Hash) && options[:header] && response.headers.present?
         response.headers[options[:header]]&.to_i
       end
+    end
+  end
+
+  def expires(options:, response:)
+    @expires ||= begin
+      if options.is_a?(Hash) && options[:header] && response.headers.present?
+        convert_expires(response.headers[options[:header]]&.to_i)
+      else
+        convert_expires(options)
+      end
+    end
+  end
+
+  def convert_expires(value)
+    if value.respond_to?(:to_datetime)
+      value.to_datetime
+    elsif value.is_a?(ActiveSupport::Duration)
+      (Time.zone.now + value).to_datetime
+    elsif value.is_a?(Integer)
+      Time.zone.at(value).to_datetime
     end
   end
 end

--- a/lib/lhc/interceptors/throttle.rb
+++ b/lib/lhc/interceptors/throttle.rb
@@ -74,11 +74,7 @@ class LHC::Throttle < LHC::Interceptor
   end
 
   def convert_expires(value)
-    if value.respond_to?(:to_datetime)
-      value.to_datetime
-    elsif value.is_a?(ActiveSupport::Duration)
-      (Time.zone.now + value).to_datetime
-    elsif value.is_a?(Integer)
+    if value.is_a?(Integer)
       Time.zone.at(value).to_datetime
     end
   end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '10.4.2'
+  VERSION ||= '10.4.3'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,5 +3,6 @@
 require 'pry'
 require 'webmock/rspec'
 require 'lhc'
+require 'timecop'
 
 Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
Having throttling expire is kind of necessary, that's also why this PR is patching the version.

Otherwise, as soon as the throttling interceptor hits the break, he will never get out of the break state again, as no further request would be allowed, which would update the current quota.