### PR TITLE
More generic rspec helper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,3 +56,6 @@ RSpec/BeforeAfterAll:
 
 Style/EmptyMethod:
   EnforcedStyle: compact
+
+RSpec/RepeatedExample:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ use it like:
                * [Bearer Authentication with client access token](#bearer-authentication-with-client-access-token)
             * [Caching Interceptor](#caching-interceptor)
                * [Options](#options)
-               * [Testing](#testing)
             * [Default Timeout Interceptor](#default-timeout-interceptor)
                * [Overwrite defaults](#overwrite-defaults)
             * [Logging Interceptor](#logging-interceptor)
@@ -83,13 +82,16 @@ use it like:
             * [Retry Interceptor](#retry-interceptor)
                * [Limit the amount of retries while making the request](#limit-the-amount-of-retries-while-making-the-request)
                * [Change the default maximum of retries of the retry interceptor](#change-the-default-maximum-of-retries-of-the-retry-interceptor)
+               * [Retry all requests](#retry-all-requests)
             * [Rollbar Interceptor](#rollbar-interceptor)
                * [Forward additional parameters](#forward-additional-parameters)
+            * [Throttle](#throttle)
             * [Zipkin](#zipkin)
          * [Create an interceptor from scratch](#create-an-interceptor-from-scratch)
             * [Interceptor callbacks](#interceptor-callbacks)
             * [Interceptor request/response](#interceptor-requestresponse)
             * [Provide a response replacement through an interceptor](#provide-a-response-replacement-through-an-interceptor)
+      * [Testing](#testing)
       * [License](#license)
 
 ## Basic methods
@@ -629,16 +631,6 @@ To avoid that case the first process to find an expired cache entry will bump th
 
 `use` - Set an explicit cache to be used for this request. If this option is missing `LHC::Caching.cache` is used.
 
-##### Testing
-
-Add to your spec_helper.rb:
-
-```ruby
-  require 'lhc/test/cache_helper.rb'
-```
-
-This will initialize a MemoryStore cache for LHC::Caching interceptor and resets the cache before every test.
-
 #### Default Timeout Interceptor
 
 Applies default timeout values to all requests made in an application, that uses LHC.
@@ -961,6 +953,16 @@ You can access the request.response to identify if a response was already provid
       return LHC::Response.new(remote_cache)
     end
   end
+```
+
+## Testing
+
+When writing tests for your application when using LHC, please make sure you require the lhc rspec test helper:
+
+```ruby
+# spec/spec_helper.rb
+
+require 'lhc/rspec'
 ```
 
 ## License

--- a/lib/lhc/rspec.rb
+++ b/lib/lhc/rspec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'lhc'
+
+RSpec.configure do |config|
+  LHC::Caching.cache = ActiveSupport::Cache::MemoryStore.new
+
+  config.before(:each) do
+    LHC::Caching.cache.clear
+    LHC::Throttle.track = nil
+  end
+end

--- a/lib/lhc/test/cache_helper.rb
+++ b/lib/lhc/test/cache_helper.rb
@@ -1,9 +1,3 @@
 # frozen_string_literal: true
 
-RSpec.configure do |config|
-  LHC::Caching.cache = ActiveSupport::Cache::MemoryStore.new
-
-  config.before(:each) do
-    LHC::Caching.cache.clear
-  end
-end
+warn("[WARNING] require 'lhc/test/cache_helper.rb' is not needed any more! Just require 'lhc/rspec' in your spec helper instead.")

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '10.4.4'
+  VERSION ||= '10.5.0'
 end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '10.4.3'
+  VERSION ||= '10.4.4'
 end

--- a/spec/interceptors/throttle/reset_track_spec.rb
+++ b/spec/interceptors/throttle/reset_track_spec.rb
@@ -39,15 +39,15 @@ describe LHC::Throttle do
   # If LHC::Trottle.track would be kept accross multiple tests,
   # at least 2/3 of the following would fail
 
-  it 'resets track accross multiple tests' do
+  it 'resets track accross multiple tests 1/3' do
     LHC.get('http://local.ch', options)
   end
 
-  it 'resets track accross multiple tests' do
+  it 'resets track accross multiple tests 2/3' do
     LHC.get('http://local.ch', options)
   end
 
-  it 'resets track accross multiple tests' do
+  it 'resets track accross multiple tests 3/3' do
     LHC.get('http://local.ch', options)
   end
 end

--- a/spec/interceptors/throttle/reset_track_spec.rb
+++ b/spec/interceptors/throttle/reset_track_spec.rb
@@ -39,15 +39,15 @@ describe LHC::Throttle do
   # If LHC::Trottle.track would be kept accross multiple tests,
   # at least 2/3 of the following would fail
 
-  it 'resets track accross multiple tests 1/3' do
+  it 'resets track' do
     LHC.get('http://local.ch', options)
   end
 
-  it 'resets track accross multiple tests 2/3' do
+  it 'accross multiple' do
     LHC.get('http://local.ch', options)
   end
 
-  it 'resets track accross multiple tests 3/3' do
+  it 'specs' do
     LHC.get('http://local.ch', options)
   end
 end

--- a/spec/interceptors/throttle/reset_track_spec.rb
+++ b/spec/interceptors/throttle/reset_track_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LHC::Throttle do
+  let(:provider) { 'local.ch' }
+  let(:limit) { 10000 }
+  let(:remaining) { 1900 }
+  let(:options) do
+    {
+      throttle: {
+        provider: provider,
+        track: true,
+        limit: limit_options,
+        remaining: { header: 'Rate-Limit-Remaining' },
+        expires: { header: 'Rate-Limit-Reset' },
+        break: '80%'
+      }
+    }
+  end
+  let(:limit_options) { { header: 'Rate-Limit-Limit' } }
+  let(:break_option) { false }
+  let(:expires_in) { (Time.zone.now + 1.hour).to_i }
+
+  before(:each) do
+    LHC::Throttle.track = nil
+    LHC.config.interceptors = [LHC::Throttle]
+
+    stub_request(:get, 'http://local.ch')
+      .to_return(
+        headers: {
+          'Rate-Limit-Limit' => limit,
+          'Rate-Limit-Remaining' => remaining,
+          'Rate-Limit-Reset' => expires_in
+        }
+      )
+  end
+
+  # If LHC::Trottle.track would be kept accross multiple tests,
+  # at least 2/3 of the following would fail
+
+  it 'resets track accross multiple tests' do
+    LHC.get('http://local.ch', options)
+  end
+
+  it 'resets track accross multiple tests' do
+    LHC.get('http://local.ch', options)
+  end
+
+  it 'resets track accross multiple tests' do
+    LHC.get('http://local.ch', options)
+  end
+end

--- a/spec/interceptors/throttle/reset_track_spec.rb
+++ b/spec/interceptors/throttle/reset_track_spec.rb
@@ -39,15 +39,15 @@ describe LHC::Throttle do
   # If LHC::Trottle.track would be kept accross multiple tests,
   # at least 2/3 of the following would fail
 
-  it 'resets track' do
+  it 'resets track accross multiple tests' do
     LHC.get('http://local.ch', options)
   end
 
-  it 'accross multiple' do
+  it 'resets track accross multiple tests' do
     LHC.get('http://local.ch', options)
   end
 
-  it 'specs' do
+  it 'resets track accross multiple tests' do
     LHC.get('http://local.ch', options)
   end
 end


### PR DESCRIPTION
This PR introduces a more generic test helper to require within your application when using LHC.

It also introduces a test to actually test Throttling track to be reset between tests.