### PR TITLE
Consider ignore_errors when retrying requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,6 +815,20 @@ If you want to retry all requests made from your application, you just need to c
   configuration.interceptors = [LHC::Retry]
 ```
 
+##### Do not retry certain response codes
+
+If you do not want to retry based on certain response codes, use retry in combination with explicit `ignore_errors`:
+
+```ruby
+  LHC.get('http://local.ch', ignore_errors: [LHC::NotFound], retry: { max: 1 })
+```
+
+Or if you use `LHC::Retry.all`:
+
+```ruby
+LHC.get('http://local.ch', ignore_errors: [LHC::NotFound])
+```
+
 #### Rollbar Interceptor
 
 Forward errors to rollbar when exceptions occur during http requests.

--- a/lib/lhc/interceptors/retry.rb
+++ b/lib/lhc/interceptors/retry.rb
@@ -24,6 +24,7 @@ class LHC::Retry < LHC::Interceptor
 
   def retry?(request)
     return false if request.response.success?
+    return false if request.error_ignored?
     return false if !request.options.dig(:retry) && !LHC::Retry.all
     request.options[:retries] < max(request)
   end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '10.5.0'
+  VERSION ||= '10.5.1'
 end


### PR DESCRIPTION
_PATCH_

This PR makes the retry interceptor consider to not retry a request if the error (response) was explicitly ignored. (Which was expected to work that way.)

#### Retry Interceptor

##### Do not retry certain response codes

If you do not want to retry based on certain response codes, use retry in combination with explicit `ignore_errors`:

```ruby
  LHC.get('http://local.ch', ignore_errors: [LHC::NotFound], retry: { max: 1 })
```

Or if you use `LHC::Retry.all`:

```ruby
LHC.get('http://local.ch', ignore_errors: [LHC::NotFound])
```