### PR TITLE
Rollbar interceptor error handling

### DIFF
--- a/lib/core_ext/hash/deep_transform_values.rb
+++ b/lib/core_ext/hash/deep_transform_values.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# This was copied from: https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/hash/deep_transform_values.rb
+class Hash
+  # Returns a new hash with all values converted by the block operation.
+  # This includes the values from the root hash and from all
+  # nested hashes and arrays.
+  #
+  #  hash = { person: { name: 'Rob', age: '28' } }
+  #
+  #  hash.deep_transform_values{ |value| value.to_s.upcase }
+  #  # => {person: {name: "ROB", age: "28"}}
+  def deep_transform_values(&block)
+    _deep_transform_values_in_object(self, &block)
+  end
+
+  # Destructively converts all values by using the block operation.
+  # This includes the values from the root hash and from all
+  # nested hashes and arrays.
+  def deep_transform_values!(&block)
+    _deep_transform_values_in_object!(self, &block)
+  end
+
+  private
+
+  # support methods for deep transforming nested hashes and arrays
+  def _deep_transform_values_in_object(object, &block)
+    case object
+    when Hash
+      object.transform_values { |value| _deep_transform_values_in_object(value, &block) }
+    when Array
+      object.map { |e| _deep_transform_values_in_object(e, &block) }
+    else
+      yield(object)
+    end
+  end
+
+  def _deep_transform_values_in_object!(object, &block)
+    case object
+    when Hash
+      object.transform_values! { |value| _deep_transform_values_in_object!(value, &block) }
+    when Array
+      object.map! { |e| _deep_transform_values_in_object!(e, &block) }
+    else
+      yield(object)
+    end
+  end
+end

--- a/lib/lhc.rb
+++ b/lib/lhc.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'typhoeus'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash/keys'

--- a/lib/lhc.rb
+++ b/lib/lhc.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 require 'typhoeus'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash/keys'
@@ -9,6 +8,8 @@ module LHC
     'lhc/concerns/lhc/basic_methods_concern'
   autoload :ConfigurationConcern,
     'lhc/concerns/lhc/configuration_concern'
+  autoload :FixInvalidEncodingConcern,
+    'lhc/concerns/lhc/fix_invalid_encoding_concern'
   autoload :FormatsConcern,
     'lhc/concerns/lhc/formats_concern'
 

--- a/lib/lhc/concerns/lhc/fix_invalid_encoding_concern.rb
+++ b/lib/lhc/concerns/lhc/fix_invalid_encoding_concern.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'active_support'
+
+module LHC
+  module FixInvalidEncodingConcern
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # fix strings that contain non-UTF8 encoding in a forceful way
+      # should none of the fix-attempts be successful,
+      # an empty string is returned instead
+      def fix_invalid_encoding(string)
+        return string unless string.is_a?(String)
+        result = string.dup
+
+        # we assume it's ISO-8859-1 first
+        if !result.valid_encoding? || !utf8?(result)
+          result.encode!('UTF-8', 'ISO-8859-1', invalid: :replace, undef: :replace, replace: '')
+        end
+
+        # if it's still an issue, try with BINARY
+        if !result.valid_encoding? || !utf8?(result)
+          result.encode!('UTF-8', 'BINARY', invalid: :replace, undef: :replace, replace: '')
+        end
+
+        # if its STILL an issue, return an empty string :(
+        if !result.valid_encoding? || !utf8?(result)
+          result = ""
+        end
+
+        result
+      end
+
+      private
+
+      def utf8?(string)
+        string.encoding == Encoding::UTF_8
+      end
+    end
+  end
+end

--- a/lib/lhc/interceptors/rollbar.rb
+++ b/lib/lhc/interceptors/rollbar.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
+require 'core_ext/hash/deep_transform_values'
 
 class LHC::Rollbar < LHC::Interceptor
   include ActiveSupport::Configurable
+  include LHC::FixInvalidEncodingConcern
 
   def after_response
     return unless Object.const_defined?('Rollbar')
@@ -23,6 +25,12 @@ class LHC::Rollbar < LHC::Interceptor
         params: request.params
       }
     }.merge additional_params
-    Rollbar.warning("Status: #{response.code} URL: #{request.url}", data)
+    begin
+      Rollbar.warning("Status: #{response.code} URL: #{request.url}", data)
+    rescue Encoding::UndefinedConversionError => e
+      sanitized_data = data.deep_transform_values { |value| self.class.fix_invalid_encoding(value) }
+      Rollbar.warning("Status: #{response.code} URL: #{request.url}", sanitized_data)
+    end
+
   end
 end

--- a/lib/lhc/interceptors/rollbar.rb
+++ b/lib/lhc/interceptors/rollbar.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'core_ext/hash/deep_transform_values'
 
 class LHC::Rollbar < LHC::Interceptor
@@ -27,10 +28,9 @@ class LHC::Rollbar < LHC::Interceptor
     }.merge additional_params
     begin
       Rollbar.warning("Status: #{response.code} URL: #{request.url}", data)
-    rescue Encoding::UndefinedConversionError => e
+    rescue Encoding::UndefinedConversionError
       sanitized_data = data.deep_transform_values { |value| self.class.fix_invalid_encoding(value) }
       Rollbar.warning("Status: #{response.code} URL: #{request.url}", sanitized_data)
     end
-
   end
 end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '10.5.2'
+  VERSION ||= '10.5.3'
 end

--- a/spec/core_ext/hash/deep_transform_values_spec.rb
+++ b/spec/core_ext/hash/deep_transform_values_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'core_ext/hash/deep_transform_values'
 
-describe 'core_ext/hash/deep_transform_values' do
+describe Hash do
   subject do
     {
       'key' => 'value',

--- a/spec/core_ext/hash/deep_transform_values_spec.rb
+++ b/spec/core_ext/hash/deep_transform_values_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'core_ext/hash/deep_transform_values'
+
+describe 'core_ext/hash/deep_transform_values' do
+  subject do
+    {
+      'key' => 'value',
+      'key2' => { 'key' => 'value', key2: 'value' }
+    }
+  end
+
+  let(:expected_result) do
+    {
+      'key' => 'VALUE',
+      'key2' => { 'key' => 'VALUE', key2: 'VALUE' }
+    }
+  end
+
+  it 'applies upcase to all values' do
+    expect(subject.deep_transform_values { |value| value.upcase }).to eq(expected_result)
+  end
+end

--- a/spec/interceptors/rollbar/invalid_encoding_spec.rb
+++ b/spec/interceptors/rollbar/invalid_encoding_spec.rb
@@ -16,16 +16,13 @@ describe LHC::Rollbar do
         call_counter += 1
         raise Encoding::UndefinedConversionError if call_counter == 1
       end
-    end
 
-
-    let(:invalid) { (+"in\xc3lid").force_encoding('ASCII-8BIT') }
-    let(:valid) { described_class.fix_invalid_encoding(invalid) }
-
-    before(:each) do
       # the response for the caller is still LHC::BadRequest
       expect(-> { LHC.get('http://local.ch', rollbar: { additional: invalid }) }).to raise_error LHC::BadRequest
     end
+
+    let(:invalid) { (+"in\xc3lid").force_encoding('ASCII-8BIT') }
+    let(:valid) { described_class.fix_invalid_encoding(invalid) }
 
     it 'calls fix_invalid_encoding incase a Encoding::UndefinedConversionError was encountered' do
       expect(described_class).to have_received(:fix_invalid_encoding).with(invalid)

--- a/spec/interceptors/rollbar/invalid_encoding_spec.rb
+++ b/spec/interceptors/rollbar/invalid_encoding_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LHC::Rollbar do
+  context 'invalid encoding in rollbar payload' do
+    before(:each) do
+      LHC.config.interceptors = [LHC::Rollbar]
+      stub_request(:get, 'http://local.ch').to_return(status: 400)
+
+      allow(described_class).to receive(:fix_invalid_encoding).and_call_original
+      # a stub that will throw a error on first call and suceed on subsequent calls
+      call_counter = 0
+      class Rollbar; end
+      ::Rollbar.stub(:warning) do
+        call_counter += 1
+        raise Encoding::UndefinedConversionError if call_counter == 1
+      end
+    end
+
+
+    let(:invalid) { (+"in\xc3lid").force_encoding('ASCII-8BIT') }
+    let(:valid) { described_class.fix_invalid_encoding(invalid) }
+
+    before(:each) do
+      # the response for the caller is still LHC::BadRequest
+      expect(-> { LHC.get('http://local.ch', rollbar: { additional: invalid }) }).to raise_error LHC::BadRequest
+    end
+
+    it 'calls fix_invalid_encoding incase a Encoding::UndefinedConversionError was encountered' do
+      expect(described_class).to have_received(:fix_invalid_encoding).with(invalid)
+    end
+
+    it 'calls Rollbar.warn with the fixed data' do
+      expect(::Rollbar).to have_received(:warning)
+        .with(
+          'Status: 400 URL: http://local.ch',
+          hash_including(
+            response: anything,
+            request: anything,
+            additional: valid
+          )
+        )
+    end
+  end
+end

--- a/spec/interceptors/rollbar/main_spec.rb
+++ b/spec/interceptors/rollbar/main_spec.rb
@@ -7,16 +7,21 @@ describe LHC::Rollbar do
     LHC.config.interceptors = [LHC::Rollbar]
   end
 
-  it 'does not report if Rollbar is not defined' do
-    stub_request(:get, 'http://local.ch').to_return(status: 400)
-    expect(-> { LHC.get('http://local.ch') })
-      .to raise_error LHC::BadRequest
+  context 'Rollbar is undefined' do
+    before(:each) do
+      Object.send(:remove_const, 'Rollbar') if Object.const_defined?('Rollbar')
+    end
+    it 'does not report' do
+      stub_request(:get, 'http://local.ch').to_return(status: 400)
+      expect(-> { LHC.get('http://local.ch') })
+        .to raise_error LHC::BadRequest
+    end
   end
 
   context 'Rollbar is defined' do
     before(:each) do
       class Rollbar; end
-      allow(::Rollbar).to receive(:warning)
+      ::Rollbar.stub(:warning)
     end
 
     it 'does report errors to rollbar' do


### PR DESCRIPTION
we have an issue on the `ratings` app where the rollbar notification results in an `Encoding::UndefinedConversionError` (https://rollbar.com/local.ch/ratings/items/10/)

we assume this masks the underlying cause of the initial rollbar warning.

this is an attempt of recovering in such a case, by sanitizing the data sent to rollbar.

# Att:

- the rspecs are a bit awkward. I did my best to make them concise
- if someone knows a better way of setting up a spy that first throws an exception and the second time not, im all ears!