### PR TITLE
Mitigate Race Condition when initialising Prometheus

### DIFF
--- a/lib/lhc/interceptors/prometheus.rb
+++ b/lib/lhc/interceptors/prometheus.rb
@@ -15,7 +15,7 @@ class LHC::Prometheus < LHC::Interceptor
   def initialize(request)
     super(request)
     return if LHC::Prometheus.registered || LHC::Prometheus.client.blank?
-    
+
     begin
       LHC::Prometheus.client.registry.counter(LHC::Prometheus::REQUEST_COUNTER_KEY, 'Counter of all LHC requests.')
       LHC::Prometheus.client.registry.histogram(LHC::Prometheus::REQUEST_HISTOGRAM_KEY, 'Request timings for all LHC requests in seconds.')

--- a/lib/lhc/interceptors/prometheus.rb
+++ b/lib/lhc/interceptors/prometheus.rb
@@ -15,9 +15,15 @@ class LHC::Prometheus < LHC::Interceptor
   def initialize(request)
     super(request)
     return if LHC::Prometheus.registered || LHC::Prometheus.client.blank?
-    LHC::Prometheus.client.registry.counter(LHC::Prometheus::REQUEST_COUNTER_KEY, 'Counter of all LHC requests.')
-    LHC::Prometheus.client.registry.histogram(LHC::Prometheus::REQUEST_HISTOGRAM_KEY, 'Request timings for all LHC requests in seconds.')
-    LHC::Prometheus.registered = true
+    
+    begin
+      LHC::Prometheus.client.registry.counter(LHC::Prometheus::REQUEST_COUNTER_KEY, 'Counter of all LHC requests.')
+      LHC::Prometheus.client.registry.histogram(LHC::Prometheus::REQUEST_HISTOGRAM_KEY, 'Request timings for all LHC requests in seconds.')
+    rescue Prometheus::Client::Registry::AlreadyRegisteredError => e
+      Rails.logger.error(e) if defined?(Rails)
+    ensure
+      LHC::Prometheus.registered = true
+    end
   end
 
   def after_response

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '11.0.0'
+  VERSION ||= '11.0.1'
 end


### PR DESCRIPTION
The setting of the registering is not atomic, so it could happen that on start up, the `registered` flag is not yet set when a second thread initialises the Prometheus interceptor again. Simply adding a rescue for this case prevents an exception.

This should be idiomatic anyway.