### PR TITLE
Do not use Typhoeus::Hydra memoization

### DIFF
--- a/lib/lhc/concerns/lhc/basic_methods_concern.rb
+++ b/lib/lhc/concerns/lhc/basic_methods_concern.rb
@@ -27,7 +27,7 @@ module LHC
       private
 
       def parallel_requests(options)
-        hydra = Typhoeus::Hydra.hydra
+        hydra = Typhoeus::Hydra.new # do not use memoization !
         requests = []
         options.each do |option|
           request = LHC::Request.new(option, false)

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '11.0.1'
+  VERSION ||= '11.0.2'
 end

--- a/spec/request/parallel_requests_spec.rb
+++ b/spec/request/parallel_requests_spec.rb
@@ -37,4 +37,23 @@ describe LHC::Request do
       expect(@called).to eq 2
     end
   end
+
+  context 'webmock disabled' do
+    before do
+      WebMock.disable!
+    end
+
+    after do
+      WebMock.enable!
+    end
+
+    it 'does not memorize parallelization handlers in typhoeus (hydra) in case one request of the parallization fails' do
+      begin
+        LHC.request([{ url: 'https://www.google.com/' }, { url: 'https://nonexisting123' }, { url: 'https://www.google.com/' }, { url: 'https://nonexisting123' }])
+      rescue LHC::UnknownError
+      end
+
+      LHC.request([{ url: 'https://www.google.com' }])
+    end
+  end
 end


### PR DESCRIPTION
This is a big one.

For those of you that know, but some of our applications are constantly suffering from `Status 0 (timeout)` responses.

Especially in AMA where there was nothing else left to do, but recycling the pods, in order to get the application stable again.

## What I think was happening

LHC uses `Typhoeus::Hydra` to parallelize requests. https://github.com/typhoeus/typhoeus/blob/master/lib/typhoeus/hydra.rb#L67

LHC used the memorized instance of Hydra.

When one single request failed during the parallelization, it left the memoized hydra in it's current state. Because every single request in the parallelization calls back, and when one of them raises an error through LHC the others will not continue, and worse, will leave the memoized hydra in it's current state.
https://github.com/local-ch/lhc/blob/master/lib/lhc/request.rb#L154

The next request parallelisation picked up the memoized hydra in it's broken state, and when it made requests to a url that was already part of the broken memoized hydra, somehow ethon due to the way they use memory pointers failed fast with the execution of those requests entirely.
https://github.com/typhoeus/ethon/blob/master/lib/ethon/multi/operations.rb#L26

It's an endless circle of Status 0 (timeouts) being served from memory (without even making the requests). That's also why neither Backend nor Devops ever seen the traffic going out of that pod, nor ending up on the BE systems.

Because hydras are memoized by thread, this explains also why applications after a recycle work and then after time start to fall into this pattern again, because each thread's memoized hydra needs to built up those broken queues first. Then when all threads are suffering from this issue, the application because unresponsive. 

## What's next

After we roll this out to our applications we should get a better feeling if this resolves the current issues we have with some of our applications.