### PR TITLE
Form format

### DIFF
--- a/lib/lhc/concerns/lhc/formats_concern.rb
+++ b/lib/lhc/concerns/lhc/formats_concern.rb
@@ -5,7 +5,6 @@ module LHC
     extend ActiveSupport::Concern
 
     module ClassMethods
-
       def form
         LHC::Formats::Form
       end

--- a/lib/lhc/concerns/lhc/formats_concern.rb
+++ b/lib/lhc/concerns/lhc/formats_concern.rb
@@ -5,6 +5,11 @@ module LHC
     extend ActiveSupport::Concern
 
     module ClassMethods
+
+      def form
+        LHC::Formats::Form
+      end
+
       def json
         LHC::Formats::JSON
       end

--- a/lib/lhc/formats.rb
+++ b/lib/lhc/formats.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module LHC::Formats
+  autoload :Form, 'lhc/formats/form'
   autoload :JSON, 'lhc/formats/json'
   autoload :Multipart, 'lhc/formats/multipart'
   autoload :Plain, 'lhc/formats/plain'

--- a/lib/lhc/formats/form.rb
+++ b/lib/lhc/formats/form.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module LHC::Formats
+  class Form < LHC::Format
+    include LHC::BasicMethodsConcern
+
+    def self.request(options)
+      options[:format] = new
+      super(options)
+    end
+
+    def format_options(options)
+      options[:headers] ||= {}
+      no_content_type_header!(options)
+      options[:headers]['Content-Type'] = 'application/x-www-form-urlencoded'
+      options
+    end
+
+    def as_json(input)
+      parse(input)
+    end
+
+    def as_open_struct(input)
+      parse(input)
+    end
+
+    def to_body(input)
+      input
+    end
+
+    def to_s
+      'form'
+    end
+
+    def to_sym
+      to_s.to_sym
+    end
+
+    private
+
+    def parse(input)
+      input
+    end
+  end
+end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '11.0.2'
+  VERSION ||= '11.1.0'
 end

--- a/spec/formats/form_spec.rb
+++ b/spec/formats/form_spec.rb
@@ -8,11 +8,12 @@ describe LHC do
   context 'form' do
 
     it 'formats requests to be application/x-www-form-urlencoded' do
-      stub_request(:post, 'http://local.ch/') do |request|
-        raise 'Body Format is wrong' unless request.body != 'client_id=1234&client_secret=4567&grant_type=client_credentials'
-        raise 'Content-Type header wrong' unless request.headers['Content-Type'] == 'application/x-www-form-urlencoded'
-      end.to_return(status: 200)
-      response = LHC.form.post(
+      stub = stub_request(:post, 'http://local.ch/')
+        .with(body: 'client_id=1234&client_secret=4567&grant_type=client_credentials')
+        .with(headers: { 'Content-Type': 'application/x-www-form-urlencoded' })
+        .to_return(status: 200)
+      
+      LHC.form.post(
         'http://local.ch',
         body: {
           client_id: '1234',
@@ -20,6 +21,8 @@ describe LHC do
           grant_type: 'client_credentials'
         }
       )
+
+      expect(stub).to have_been_requested
     end
   end
 end

--- a/spec/formats/form_spec.rb
+++ b/spec/formats/form_spec.rb
@@ -6,13 +6,12 @@ describe LHC do
   include ActionDispatch::TestProcess
 
   context 'form' do
-
     it 'formats requests to be application/x-www-form-urlencoded' do
       stub = stub_request(:post, 'http://local.ch/')
         .with(body: 'client_id=1234&client_secret=4567&grant_type=client_credentials')
         .with(headers: { 'Content-Type': 'application/x-www-form-urlencoded' })
         .to_return(status: 200)
-      
+
       LHC.form.post(
         'http://local.ch',
         body: {

--- a/spec/formats/form_spec.rb
+++ b/spec/formats/form_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LHC do
+  include ActionDispatch::TestProcess
+
+  context 'form' do
+
+    it 'formats requests to be application/x-www-form-urlencoded' do
+      stub_request(:post, 'http://local.ch/') do |request|
+        raise 'Body Format is wrong' unless request.body != 'client_id=1234&client_secret=4567&grant_type=client_credentials'
+        raise 'Content-Type header wrong' unless request.headers['Content-Type'] == 'application/x-www-form-urlencoded'
+      end.to_return(status: 200)
+      response = LHC.form.post(
+        'http://local.ch',
+        body: {
+          client_id: '1234',
+          client_secret: '4567',
+          grant_type: 'client_credentials'
+        }
+      )
+    end
+  end
+end

--- a/spec/formats/multipart_spec.rb
+++ b/spec/formats/multipart_spec.rb
@@ -10,7 +10,7 @@ describe LHC do
     let(:body) { { size: 2231 }.to_json }
     let(:location) { 'http://local.ch/uploads/image.jpg' }
 
-    it 'leaves plains requests unformatted' do
+    it 'formats requests to be multipart/form-data' do
       stub_request(:post, 'http://local.ch/') do |request|
         raise 'Content-Type header wrong' unless request.headers['Content-Type'] == 'multipart/form-data'
         raise 'Body wrongly formatted' unless request.body.match(/file=%23%3CActionDispatch%3A%3AHttp%3A%3AUploadedFile%3A.*%3E&type=Image/)


### PR DESCRIPTION
This PR adds the `form` format, which allows to make easy `application/x-www-form-urlencoded` requests with an urlencoded body.

Needed for sf token issuing.