### PR TITLE
Token format to evaluate reauthenticate? was too strict

### DIFF
--- a/lib/lhc/interceptors/auth.rb
+++ b/lib/lhc/interceptors/auth.rb
@@ -66,7 +66,7 @@ class LHC::Auth < LHC::Interceptor
   end
 
   def bearer_header_present?
-    @has_bearer_header ||= request.headers['Authorization'] =~ /^Bearer [0-9a-f-]+$/i
+    @has_bearer_header ||= request.headers['Authorization'] =~ /^Bearer .+$/i
   end
 
   def refresh_client_token_option

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '11.1.0'
+  VERSION ||= '11.1.1'
 end

--- a/spec/interceptors/auth/reauthentication_spec.rb
+++ b/spec/interceptors/auth/reauthentication_spec.rb
@@ -31,4 +31,14 @@ describe LHC::Auth do
     LHC.config.endpoint(:local, 'http://local.ch', auth: options.merge(reauthenticated: true))
     expect { LHC.get(:local) }.to raise_error(LHC::Unauthorized)
   end
+
+  context 'token format' do
+    let(:initial_token) { 'BAsZ-98-ZZZ' }
+
+    it 'refreshes tokens with various formats' do
+      LHC.config.endpoint(:local, 'http://local.ch', auth: options)
+      LHC.get(:local)
+      expect(auth_suceeding_after_recovery).to have_been_made.once
+    end
+  end
 end


### PR DESCRIPTION
When this feature was introduced, there was only 1 bearer token format, the one from auth.local.ch. 

Now with Salesforce we have a second bearer token issuer, and this PR weakens the criterias under which a `reauthenticate?` is performed to refresh client tokens.