### PR TITLE
allow single keys to be passed as ignored_errors

### DIFF
--- a/lib/lhc/error.rb
+++ b/lib/lhc/error.rb
@@ -59,6 +59,10 @@ class LHC::Error < StandardError
     self.response = response
   end
 
+  def self.to_a
+    [self]
+  end
+
   def to_s
     return response if response.is_a?(String)
     request = response.request

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -15,7 +15,7 @@ class LHC::Request
   attr_accessor :response, :options, :raw, :format, :error_handler, :errors_ignored, :source
 
   def initialize(options, self_executing = true)
-    self.errors_ignored = (options.fetch(:ignored_errors, []) || []).compact
+    self.errors_ignored = (options.fetch(:ignored_errors, []) || []).to_a.compact
     self.source = options&.dig(:source)
     self.options = format!(options.deep_dup || {})
     self.error_handler = options.delete :error_handler

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '11.1.1'
+  VERSION ||= '11.2.0'
 end

--- a/spec/request/ignore_errors_spec.rb
+++ b/spec/request/ignore_errors_spec.rb
@@ -62,4 +62,12 @@ describe LHC::Request do
       }.to raise_error(LHC::NotFound)
     end
   end
+
+  context 'passing keys instead of arrays' do
+    before { stub_request(:get, 'http://local.ch').to_return(status: 404) }
+
+    it "does not raise an error when ignored errors is a key instead of an array" do
+      LHC.get('http://local.ch', ignored_errors: LHC::NotFound)
+    end    
+  end
 end

--- a/spec/request/ignore_errors_spec.rb
+++ b/spec/request/ignore_errors_spec.rb
@@ -68,6 +68,6 @@ describe LHC::Request do
 
     it "does not raise an error when ignored errors is a key instead of an array" do
       LHC.get('http://local.ch', ignored_errors: LHC::NotFound)
-    end    
+    end
   end
 end


### PR DESCRIPTION
We discovered a bug in LHS where including resources that can not be found wouldn't work as expected.

This is a first improvement (minor) to solve the overall issue.