### PR TITLE
ignore is the new ignored_errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,8 +424,10 @@ but you often want to continue working with `nil`, LHC provides the `ignore` opt
 
 Errors listed in this option will not be raised and will leave the `response.body` and `response.data` to stay `nil`.
 
+You can either pass the LHC error class you want to be ignored or an array of LHC error classes.
+
 ```ruby
-response = LHC.get('http://something', ignore: [LHC::NotFound])
+response = LHC.get('http://something', ignore: LHC::NotFound)
 
 response.body # nil
 response.data # nil
@@ -820,13 +822,13 @@ If you want to retry all requests made from your application, you just need to c
 If you do not want to retry based on certain response codes, use retry in combination with explicit `ignore`:
 
 ```ruby
-  LHC.get('http://local.ch', ignore: [LHC::NotFound], retry: { max: 1 })
+  LHC.get('http://local.ch', ignore: LHC::NotFound, retry: { max: 1 })
 ```
 
 Or if you use `LHC::Retry.all`:
 
 ```ruby
-LHC.get('http://local.ch', ignore: [LHC::NotFound])
+LHC.get('http://local.ch', ignore: LHC::NotFound)
 ```
 
 #### Rollbar Interceptor

--- a/README.md
+++ b/README.md
@@ -420,12 +420,12 @@ response.data.name # 'unknown'
 ### Ignore certain errors
 
 As it's discouraged to rescue errors and then don't handle them (ruby styleguide)[https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions],
-but you often want to continue working with `nil`, LHC provides the `ignored_errors` option.
+but you often want to continue working with `nil`, LHC provides the `ignore` option.
 
 Errors listed in this option will not be raised and will leave the `response.body` and `response.data` to stay `nil`.
 
 ```ruby
-response = LHC.get('http://something', ignored_errors: [LHC::NotFound])
+response = LHC.get('http://something', ignore: [LHC::NotFound])
 
 response.body # nil
 response.data # nil
@@ -817,16 +817,16 @@ If you want to retry all requests made from your application, you just need to c
 
 ##### Do not retry certain response codes
 
-If you do not want to retry based on certain response codes, use retry in combination with explicit `ignore_errors`:
+If you do not want to retry based on certain response codes, use retry in combination with explicit `ignore`:
 
 ```ruby
-  LHC.get('http://local.ch', ignore_errors: [LHC::NotFound], retry: { max: 1 })
+  LHC.get('http://local.ch', ignore: [LHC::NotFound], retry: { max: 1 })
 ```
 
 Or if you use `LHC::Retry.all`:
 
 ```ruby
-LHC.get('http://local.ch', ignore_errors: [LHC::NotFound])
+LHC.get('http://local.ch', ignore: [LHC::NotFound])
 ```
 
 #### Rollbar Interceptor

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -15,7 +15,7 @@ class LHC::Request
   attr_accessor :response, :options, :raw, :format, :error_handler, :errors_ignored, :source
 
   def initialize(options, self_executing = true)
-    self.errors_ignored = (options.fetch(:ignored_errors, []) || []).to_a.compact
+    self.errors_ignored = (options.fetch(:ignore, []) || []).to_a.compact
     self.source = options&.dig(:source)
     self.options = format!(options.deep_dup || {})
     self.error_handler = options.delete :error_handler

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '11.2.0'
+  VERSION ||= '12.0.0'
 end

--- a/spec/interceptors/retry/main_spec.rb
+++ b/spec/interceptors/retry/main_spec.rb
@@ -66,7 +66,7 @@ describe LHC::Rollbar do
 
     it 'does not retry if the error is explicitly ignored' do
       request_stub
-      LHC.get('http://local.ch', retry: { max: 1 }, ignored_errors: [LHC::NotFound])
+      LHC.get('http://local.ch', retry: { max: 1 }, ignore: [LHC::NotFound])
       expect(request_stub).to have_been_requested.times(1)
     end
   end

--- a/spec/request/ignore_errors_spec.rb
+++ b/spec/request/ignore_errors_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe LHC::Request do
   context 'ignoring LHC::NotFound' do
-    let(:response) { LHC.get('http://local.ch', ignored_errors: [LHC::NotFound]) }
+    let(:response) { LHC.get('http://local.ch', ignore: [LHC::NotFound]) }
 
     before { stub_request(:get, 'http://local.ch').to_return(status: 404) }
 
@@ -36,13 +36,13 @@ describe LHC::Request do
 
     it "does not raise an error when it's a subclass of the ignored error" do
       expect {
-        LHC.get('http://local.ch', ignored_errors: [LHC::Error])
+        LHC.get('http://local.ch', ignore: [LHC::Error])
       }.not_to raise_error
     end
 
     it "does raise an error if it's not a subclass of the ignored error" do
       expect {
-        LHC.get('http://local.ch', ignored_errors: [ArgumentError])
+        LHC.get('http://local.ch', ignore: [ArgumentError])
       }.to raise_error(LHC::NotFound)
     end
   end
@@ -52,13 +52,13 @@ describe LHC::Request do
 
     it "does not raise an error when ignored errors is set to array with nil" do
       expect {
-        LHC.get('http://local.ch', ignored_errors: [nil])
+        LHC.get('http://local.ch', ignore: [nil])
       }.to raise_error(LHC::NotFound)
     end
 
     it "does not raise an error when ignored errors is set to nil" do
       expect {
-        LHC.get('http://local.ch', ignored_errors: nil)
+        LHC.get('http://local.ch', ignore: nil)
       }.to raise_error(LHC::NotFound)
     end
   end
@@ -67,7 +67,7 @@ describe LHC::Request do
     before { stub_request(:get, 'http://local.ch').to_return(status: 404) }
 
     it "does not raise an error when ignored errors is a key instead of an array" do
-      LHC.get('http://local.ch', ignored_errors: LHC::NotFound)
+      LHC.get('http://local.ch', ignore: LHC::NotFound)
     end
   end
 end


### PR DESCRIPTION
`ignored_errors` has been for a long time being the only option applied to LHC requests which was not following the general, verb-kind-a wording that we use for all the other options and methods, like `.get`, `cache:`, `retry:` etc.

This PR renames the `ignored_errors:` option to `ignore:`.

# Migration Guide

- rename all `ignored_errors` to `ignore` in your entire project