### PR TITLE
[PRO-1186] More auth options

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,6 @@ Adds the following to the request body:
   'userToken': 'dheur5hrk3'
 ```
 
-
 ##### Reauthenticate
 
 The current implementation can only offer reauthenticate for _client access tokens_. For this to work the following has to be given:

--- a/README.md
+++ b/README.md
@@ -549,6 +549,31 @@ Adds the following header to the request:
 
 Which is the base64 encoded credentials "username:password".
 
+##### API Key Authentication
+
+##### Header
+
+```ruby
+  LHC.get('http://local.ch', api_key: { key: 'apitoken', value: '5hguebb44', add_to: :header })
+```
+
+Adds the following header to the request:
+```
+  'apitoken': '5hguebb44'
+```
+
+##### Body 
+
+```ruby
+  LHC.get('http://local.ch', api_key: { key: 'userToken', value: 'dheur5hrk3', add_to: :body })
+```
+
+Adds the following to the request body:
+```
+  'userToken': 'dheur5hrk3'
+```
+
+
 ##### Reauthenticate
 
 The current implementation can only offer reauthenticate for _client access tokens_. For this to work the following has to be given:

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '12.0.3'
+  VERSION ||= '12.1.0'
 end

--- a/spec/interceptors/auth/api_key_spec.rb
+++ b/spec/interceptors/auth/api_key_spec.rb
@@ -24,5 +24,3 @@ describe LHC::Auth do
     LHC.post(:local, body: { 'foo' => 'bar' })
   end
 end
-
-# TODO also update readme

--- a/spec/interceptors/auth/api_key_spec.rb
+++ b/spec/interceptors/auth/api_key_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LHC::Auth do
+  before(:each) do
+    LHC.config.interceptors = [LHC::Auth]
+  end
+
+  it 'adds the api key to the header of every request' do
+    options = { api_key: { key: 'apitoken', value: '5hguebb44', add_to: :header } }
+    LHC.config.endpoint(:local, 'http://local.ch', auth: options)
+    stub_request(:get, 'http://local.ch').with(headers: { 'apitoken' => '5hguebb44' })
+    LHC.get(:local)
+  end
+
+  it 'adds the api key to the body of every request' do
+    options = { api_key: { key: 'userToken', value: 'dheur5hrk3', add_to: :body } }
+    LHC.config.endpoint(:local, 'http://local.ch', auth: options)
+    stub_request(:post, 'http://local.ch').with(body: {
+                                                  'userToken' => 'dheur5hrk3',
+                                                  'foo' => 'bar'
+                                                })
+    LHC.post(:local, body: { 'foo' => 'bar' })
+  end
+end
+
+# TODO also update readme


### PR DESCRIPTION
Ticket: https://jira.localsearch.ch/browse/PRO-1186

Introduce two new Auth options which are used to make API Calls against the Mono API for creating One-Click Sites.

About the auth in the body:
I could not introduce a method `body` to the Request as the body-options on raw is a json string and the body on the options is a hash. So i concentrated on the raw as this is also used in the end for doing the actual request.
Any optimizations tips are very welcome. 🙏🏻