### PR TITLE
No instance variable for auth options

### DIFF
--- a/lib/lhc/interceptors/auth.rb
+++ b/lib/lhc/interceptors/auth.rb
@@ -80,7 +80,7 @@ class LHC::Auth < LHC::Interceptor
   end
 
   def auth_options
-    @auth_options ||= request.options[:auth].dup || {}
+    request.options[:auth] || {}
   end
 
   def configuration_correct?

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '12.1.0'
+  VERSION ||= '12.1.1'
 end

--- a/spec/interceptors/auth/no_instance_var_for_options_spec.rb
+++ b/spec/interceptors/auth/no_instance_var_for_options_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LHC::Auth do
+  before(:each) do
+    class AuthPrepInterceptor < LHC::Interceptor
+
+      def before_request
+        request.options[:auth] = { bearer: 'sometoken' }
+      end
+    end
+
+    LHC.config.interceptors = [AuthPrepInterceptor, LHC::Auth]
+  end
+
+  after do
+    LHC.config.reset
+  end
+
+  it 'does not use instance variables internally so that other interceptors can still change auth options' do
+    stub_request(:get, "http://local.ch/")
+      .with(headers: { 'Authorization' => 'Bearer sometoken' })
+        .to_return(status: 200)
+    LHC.get('http://local.ch')
+  end
+end

--- a/spec/interceptors/auth/no_instance_var_for_options_spec.rb
+++ b/spec/interceptors/auth/no_instance_var_for_options_spec.rb
@@ -21,7 +21,7 @@ describe LHC::Auth do
   it 'does not use instance variables internally so that other interceptors can still change auth options' do
     stub_request(:get, "http://local.ch/")
       .with(headers: { 'Authorization' => 'Bearer sometoken' })
-        .to_return(status: 200)
+      .to_return(status: 200)
     LHC.get('http://local.ch')
   end
 end


### PR DESCRIPTION
https://github.com/local-ch/lhc/releases/tag/v12.1.0 introduced a bug. 

Because the auth interceptors uses instance variables for `auth_options` once it has been initalized with the `before_raw_request` hook (as used by body  auth) other interceptors can not pass auth options anymore even at a later hook (`before_request`).

This PR removes the instance variable usage and lets auth interceptor always access the original auth option hash. So that other interceptor can prepare those options (like LHS auto auth interceptor).