### PR TITLE
Fix nested base data response accessors

### DIFF
--- a/lib/lhc/response/data.rb
+++ b/lib/lhc/response/data.rb
@@ -12,9 +12,9 @@ class LHC::Response::Data
     @data = data
 
     if as_json.is_a?(Hash)
-      @base = LHC::Response::Data::Item.new(response, data: data)
+      @base = LHC::Response::Data::Item.new(@response, data: data)
     elsif as_json.is_a?(Array)
-      @base = LHC::Response::Data::Collection.new(response, data: data)
+      @base = LHC::Response::Data::Collection.new(@response, data: data)
     end
   end
 

--- a/lib/lhc/response/data/base.rb
+++ b/lib/lhc/response/data/base.rb
@@ -4,7 +4,7 @@
 # but made accssible in the ruby world
 module LHC::Response::Data::Base
   def as_json
-    @json ||= (@data || response.format.as_json(response.body))
+    @json ||= (@data || @response.format.as_json(@response.body))
   end
 
   def as_open_struct
@@ -12,11 +12,7 @@ module LHC::Response::Data::Base
       if @data
         JSON.parse(@data.to_json, object_class: OpenStruct)
       else
-        response.format.as_open_struct(response.body)
+        @response.format.as_open_struct(@response.body)
       end
   end
-
-  private
-
-  attr_reader :response
 end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '12.1.1'
+  VERSION ||= '12.1.2'
 end

--- a/spec/response/data_spec.rb
+++ b/spec/response/data_spec.rb
@@ -58,4 +58,27 @@ describe LHC::Response do
       end
     end
   end
+
+  context 'response data if responding error data contains a response' do
+
+    before do
+      stub_request(:get, "http://listings/")
+        .to_return(status: 404, body: {
+          meta: {
+            errors: [
+              { code: 2000, msg: 'I like to hide error messages (this is meta).' }
+            ]
+          },
+          response: 'why not?'
+        }.to_json)
+    end
+
+    it 'does not through a stack level to deep issue when accessing data in a rescue context' do
+      LHC.get('http://listings')
+    rescue LHC::Error => error
+      expect(
+        error.response.request.response.data.meta.errors.detect { |item| item.code == 2000 }.name
+      ).to eq 'I like to hide error messages (this is meta).'
+    end
+  end
 end

--- a/spec/response/data_spec.rb
+++ b/spec/response/data_spec.rb
@@ -72,7 +72,7 @@ describe LHC::Response do
         }.to_json)
     end
 
-    it 'does not through a stack level to deep issue when accessing data in a rescue context' do
+    it 'does not throw a stack level to deep issue when accessing data in a rescue context' do
       begin
         LHC.get('http://listings')
       rescue LHC::Error => error

--- a/spec/response/data_spec.rb
+++ b/spec/response/data_spec.rb
@@ -60,7 +60,6 @@ describe LHC::Response do
   end
 
   context 'response data if responding error data contains a response' do
-
     before do
       stub_request(:get, "http://listings/")
         .to_return(status: 404, body: {
@@ -74,11 +73,13 @@ describe LHC::Response do
     end
 
     it 'does not through a stack level to deep issue when accessing data in a rescue context' do
-      LHC.get('http://listings')
-    rescue LHC::Error => error
-      expect(
-        error.response.request.response.data.meta.errors.detect { |item| item.code == 2000 }.msg
-      ).to eq 'I like to hide error messages (this is meta).'
+      begin
+        LHC.get('http://listings')
+      rescue LHC::Error => error
+        expect(
+          error.response.request.response.data.meta.errors.detect { |item| item.code == 2000 }.msg
+        ).to eq 'I like to hide error messages (this is meta).'
+      end
     end
   end
 end

--- a/spec/response/data_spec.rb
+++ b/spec/response/data_spec.rb
@@ -77,7 +77,7 @@ describe LHC::Response do
       LHC.get('http://listings')
     rescue LHC::Error => error
       expect(
-        error.response.request.response.data.meta.errors.detect { |item| item.code == 2000 }.name
+        error.response.request.response.data.meta.errors.detect { |item| item.code == 2000 }.msg
       ).to eq 'I like to hide error messages (this is meta).'
     end
   end


### PR DESCRIPTION
When error response bodies where containing a "response" key, lhc's internal Data::Base was running into a `SystemStackError: stack level too deep` error (e.g. https://rollbar.com/local.ch/opm/items/83972/occurrences/133328495053/).

This PR fixes that issue.