### PR TITLE
PRO-1313 Allow Procs For All Configuration Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,16 +895,22 @@ LHC.get('http://local.ch', options)
 LHC.get('http://local.ch', options)
 # raises LHC::Throttle::OutOfQuota: Reached predefined quota for local.ch
 ```
+
 **Options Description**
 * `track`: enables tracking of current limit/remaining requests of rate-limiting
 * `break`: quota in percent after which errors are raised. Percentage symbol is optional, values will be converted to integer (e.g. '23.5' will become 23)
 * `provider`: name of the provider under which throttling tracking is aggregated,
-* `limit`: either a hard-coded integer, or a hash pointing at the response header containing the limit value
+* `limit`:
+  * a hard-coded integer
+  * a hash pointing at the response header containing the limit value
+  * a proc that receives the response as argument and returns the limit value
 * `remaining`:
   * a hash pointing at the response header containing the current amount of remaining requests
-  * a proc that receives the response as argument and returns the current amount
-  of remaining requests
-* `expires`: a hash pointing at the response header containing the timestamp when the quota will reset
+  * a proc that receives the response as argument and returns the current amount of remaining requests
+* `expires`:
+  * a hash pointing at the response header containing the timestamp when the quota will reset
+  * a proc that receives the response as argument and returns the timestamp when the quota will reset
+
 
 #### Zipkin
 

--- a/lib/lhc/interceptors/throttle.rb
+++ b/lib/lhc/interceptors/throttle.rb
@@ -49,13 +49,13 @@ class LHC::Throttle < LHC::Interceptor
 
   def limit(options:, response:)
     @limit ||=
-      begin
-        if options.is_a?(Integer)
-          options
-        elsif options.is_a?(Hash) && options[:header]
-          response.headers[options[:header]]&.to_i
-        end
-      end
+      if options.is_a?(Proc)
+        options.call(response)
+      elsif options.is_a?(Integer)
+        options
+      elsif options.is_a?(Hash) && options[:header]
+        response.headers[options[:header]]&.to_i
+    end
   end
 
   def remaining(options:, response:)
@@ -79,6 +79,7 @@ class LHC::Throttle < LHC::Interceptor
 
   def convert_expires(value)
     return if value.blank?
+    return value.call(response) if value.is_a?(Proc)
     return Time.parse(value) if value.match(/GMT/)
     Time.zone.at(value.to_i).to_datetime
   end

--- a/lib/lhc/interceptors/throttle.rb
+++ b/lib/lhc/interceptors/throttle.rb
@@ -55,7 +55,7 @@ class LHC::Throttle < LHC::Interceptor
         options
       elsif options.is_a?(Hash) && options[:header]
         response.headers[options[:header]]&.to_i
-    end
+      end
   end
 
   def remaining(options:, response:)

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '12.2.1'
+  VERSION ||= '12.3.0'
 end


### PR DESCRIPTION
## Jira
https://jira.localsearch.ch/browse/pro-1313

## Changes
Allow all values that deal with header information to be procs.