### PR TITLE
Monitor Caching

### DIFF
--- a/lib/lhc/concerns/lhc/request/user_agent_concern.rb
+++ b/lib/lhc/concerns/lhc/request/user_agent_concern.rb
@@ -14,7 +14,7 @@ module LHC
           application = nil
           if defined?(Rails)
             app_class = Rails.application.class
-            application = app_class.module_parent_name
+            application = (ActiveSupport.gem_version >= Gem::Version.new('6.0.0')) ? app_class.module_parent_name : app_class.parent_name
           end
 
           "LHC (#{[version, application].compact.join('; ')}) [https://github.com/local-ch/lhc]"

--- a/lib/lhc/concerns/lhc/request/user_agent_concern.rb
+++ b/lib/lhc/concerns/lhc/request/user_agent_concern.rb
@@ -14,7 +14,7 @@ module LHC
           application = nil
           if defined?(Rails)
             app_class = Rails.application.class
-            application = (ActiveSupport.gem_version >= Gem::Version.new('6.0.0')) ? app_class.module_parent_name : app_class.parent_name
+            application = app_class.module_parent_name
           end
 
           "LHC (#{[version, application].compact.join('; ')}) [https://github.com/local-ch/lhc]"

--- a/lib/lhc/error.rb
+++ b/lib/lhc/error.rb
@@ -67,6 +67,8 @@ class LHC::Error < StandardError
     return response.to_s unless response.is_a?(LHC::Response)
     request = response.request
     return unless request.is_a?(LHC::Request)
+    
+    debug = []
     debug << [request.method, request.url].map { |str| self.class.fix_invalid_encoding(str) }.join(' ')
     debug << "Options: #{request.options}"
     debug << "Headers: #{request.headers}"

--- a/lib/lhc/error.rb
+++ b/lib/lhc/error.rb
@@ -64,9 +64,9 @@ class LHC::Error < StandardError
   end
 
   def to_s
-    return response if response.is_a?(String)
+    return response.to_s unless response.is_a?(LHC::Response)
     request = response.request
-    debug = []
+    return unless request.is_a?(LHC::Request)
     debug << [request.method, request.url].map { |str| self.class.fix_invalid_encoding(str) }.join(' ')
     debug << "Options: #{request.options}"
     debug << "Headers: #{request.headers}"

--- a/lib/lhc/error.rb
+++ b/lib/lhc/error.rb
@@ -67,7 +67,7 @@ class LHC::Error < StandardError
     return response.to_s unless response.is_a?(LHC::Response)
     request = response.request
     return unless request.is_a?(LHC::Request)
-    
+
     debug = []
     debug << [request.method, request.url].map { |str| self.class.fix_invalid_encoding(str) }.join(' ')
     debug << "Options: #{request.options}"

--- a/lib/lhc/interceptor.rb
+++ b/lib/lhc/interceptor.rb
@@ -29,4 +29,8 @@ class LHC::Interceptor
   def self.dup
     self
   end
+
+  def all_interceptor_classes
+    @all_interceptors ||= LHC::Interceptors.new(request).all.map(&:class)
+  end
 end

--- a/lib/lhc/interceptors/auth.rb
+++ b/lib/lhc/interceptors/auth.rb
@@ -75,10 +75,6 @@ class LHC::Auth < LHC::Interceptor
     @refresh_client_token_option ||= auth_options[:refresh_client_token] || refresh_client_token
   end
 
-  def all_interceptor_classes
-    @all_interceptors ||= LHC::Interceptors.new(request).all.map(&:class)
-  end
-
   def auth_options
     request.options[:auth] || {}
   end

--- a/lib/lhc/interceptors/caching.rb
+++ b/lib/lhc/interceptors/caching.rb
@@ -41,7 +41,6 @@ class LHC::Caching < LHC::Interceptor
 
   def before_request
     return unless cache?(request)
-    key = key(request, options[:key])
     return if response_data.blank?
     from_cache(request, response_data)
   end
@@ -59,8 +58,10 @@ class LHC::Caching < LHC::Interceptor
 
   private
 
-  def response_data # from cache
-    return @response_data if defined? @response_data # stop calling multi-level cache if it already returned nil for this interceptor instance
+  # from cache
+  def response_data
+    # stop calling multi-level cache if it already returned nil for this interceptor instance
+    return @response_data if defined? @response_data
     @response_data ||= multilevel_cache.fetch(key(request, options[:key]))
   end
 

--- a/lib/lhc/interceptors/caching.rb
+++ b/lib/lhc/interceptors/caching.rb
@@ -42,7 +42,7 @@ class LHC::Caching < LHC::Interceptor
   def before_request
     return unless cache?(request)
     key = key(request, options[:key])
-    return unless response_data
+    return if response_data.blank?
     from_cache(request, response_data)
   end
 
@@ -60,6 +60,7 @@ class LHC::Caching < LHC::Interceptor
   private
 
   def response_data # from cache
+    return @response_data if defined? @response_data # stop calling multi-level cache if it already returned nil for this interceptor instance
     @response_data ||= multilevel_cache.fetch(key(request, options[:key]))
   end
 

--- a/lib/lhc/interceptors/monitoring.rb
+++ b/lib/lhc/interceptors/monitoring.rb
@@ -65,12 +65,16 @@ class LHC::Monitoring < LHC::Interceptor
     url = sanitize_url(request.url)
     key = [
       'lhc',
-      Rails.application.class.module_parent_name.underscore,
+      module_parent_name.underscore,
       LHC::Monitoring.env || Rails.env,
       URI.parse(url).host.gsub(/\./, '_'),
       request.method
     ]
     key.join('.')
+  end
+
+  def module_parent_name
+    (ActiveSupport.gem_version >= Gem::Version.new('6.0.0')) ? Rails.application.class.module_parent_name : Rails.application.class.parent_name
   end
 
   def sanitize_url(url)

--- a/lib/lhc/interceptors/monitoring.rb
+++ b/lib/lhc/interceptors/monitoring.rb
@@ -13,27 +13,46 @@ class LHC::Monitoring < LHC::Interceptor
 
   def before_request
     return unless statsd
-    LHC::Monitoring.statsd.count("#{key(request)}.before_request", 1)
+    LHC::Monitoring.statsd.count("#{key}.before_request", 1)
   end
 
   def after_request
     return unless statsd
-    LHC::Monitoring.statsd.count("#{key(request)}.count", 1)
-    LHC::Monitoring.statsd.count("#{key(request)}.after_request", 1)
+    LHC::Monitoring.statsd.count("#{key}.count", 1)
+    LHC::Monitoring.statsd.count("#{key}.after_request", 1)
   end
 
   def after_response
     return unless statsd
-    key = key(response)
-    LHC::Monitoring.statsd.timing("#{key}.time", response.time) if response.success?
-    key += response.timeout? ? '.timeout' : ".#{response.code}"
-    LHC::Monitoring.statsd.count(key, 1)
+    monitor_time!
+    monitor_cache!
+    monitor_response!
   end
 
   private
 
-  def key(target)
-    request = target.is_a?(LHC::Request) ? target : target.request
+  def monitor_time!
+    LHC::Monitoring.statsd.timing("#{key}.time", response.time) if response.success?
+  end
+
+  def monitor_cache!
+    return if request.options[:cache].blank?
+    if response.from_cache?
+      LHC::Monitoring.statsd.count("#{key}.cache.hit", 1)
+    else
+      LHC::Monitoring.statsd.count("#{key}.cache.miss", 1)
+    end
+  end
+
+  def monitor_response!
+    if response.timeout?
+      LHC::Monitoring.statsd.count("#{key}.timeout", 1)
+    else
+      LHC::Monitoring.statsd.count("#{key}.#{response.code}", 1)
+    end
+  end
+
+  def key
     key = options(request.options)[:key]
     return key if key.present?
 

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -132,8 +132,11 @@ class LHC::Request
   end
 
   def on_complete(response)
-    self.response = response if response.is_a?(LHC::Response)
-    self.response ||= LHC::Response.new(response, self)
+    self.response = if response.is_a?(LHC::Response)
+      response
+    else
+      LHC::Response.new(response, self)
+    end
     interceptors.intercept(:after_response)
     handle_error(self.response) unless self.response.success?
   end

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -132,7 +132,7 @@ class LHC::Request
   end
 
   def on_complete(response)
-    self.response ||= LHC::Response.new(response, self)
+    self.response = LHC::Response.new(response, self)
     interceptors.intercept(:after_response)
     handle_error(self.response) unless self.response.success?
   end

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -132,7 +132,8 @@ class LHC::Request
   end
 
   def on_complete(response)
-    self.response = LHC::Response.new(response, self)
+    self.response = response if response.is_a?(LHC::Response)
+    self.response ||= LHC::Response.new(response, self)
     interceptors.intercept(:after_response)
     handle_error(self.response) unless self.response.success?
   end

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -25,7 +25,11 @@ class LHC::Request
     interceptors.intercept(:before_raw_request)
     self.raw = create_request
     interceptors.intercept(:before_request)
-    run! if self_executing && !response
+    if self_executing && !response
+      run!
+    elsif response
+      on_complete(response)
+    end
   end
 
   def url
@@ -128,7 +132,7 @@ class LHC::Request
   end
 
   def on_complete(response)
-    self.response = LHC::Response.new(response, self)
+    self.response ||= LHC::Response.new(response, self)
     interceptors.intercept(:after_response)
     handle_error(self.response) unless self.response.success?
   end

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -132,11 +132,7 @@ class LHC::Request
   end
 
   def on_complete(response)
-    self.response = if response.is_a?(LHC::Response)
-      response
-    else
-      LHC::Response.new(response, self)
-    end
+    self.response = response.is_a?(LHC::Response) ? response : LHC::Response.new(response, self)
     interceptors.intercept(:after_response)
     handle_error(self.response) unless self.response.success?
   end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '13.0.0'
+  VERSION ||= '13.1.0'
 end

--- a/spec/error/to_s_spec.rb
+++ b/spec/error/to_s_spec.rb
@@ -45,7 +45,7 @@ describe LHC::Error do
 
     context 'some mocked response' do
       let(:request) do
-        double('request',
+        double('LHC::Request',
                method: 'GET',
                url: 'http://example.com/sessions',
                headers: { 'Bearer Token' => "aaaaaaaa-bbbb-cccc-dddd-eeee" },
@@ -55,7 +55,7 @@ describe LHC::Error do
       end
 
       let(:response) do
-        double('response',
+        double('LHC::Response',
                request: request,
                code: 500,
                options: { return_code: :internal_error, response_headers: "" },
@@ -63,6 +63,11 @@ describe LHC::Error do
       end
 
       subject { LHC::Error.new('The error message', response) }
+
+      before do
+        allow(request).to receive(:is_a?).with(LHC::Request).and_return(true)
+        allow(response).to receive(:is_a?).with(LHC::Response).and_return(true)
+      end
 
       it 'produces correct debug output' do
         expect(subject.to_s.split("\n")).to eq(<<-MSG.strip_heredoc.split("\n"))

--- a/spec/interceptors/after_response_spec.rb
+++ b/spec/interceptors/after_response_spec.rb
@@ -14,7 +14,7 @@ describe LHC do
           uri = URI.parse(response.request.url)
           path = [
             'web',
-            Rails.application.class.module_parent_name,
+            ((ActiveSupport.gem_version >= Gem::Version.new('6.0.0')) ? Rails.application.class.module_parent_name : Rails.application.class.parent_name).underscore,
             Rails.env,
             response.request.method,
             uri.scheme,

--- a/spec/interceptors/after_response_spec.rb
+++ b/spec/interceptors/after_response_spec.rb
@@ -14,7 +14,7 @@ describe LHC do
           uri = URI.parse(response.request.url)
           path = [
             'web',
-            Rails.application.class.parent_name,
+            Rails.application.class.module_parent_name,
             Rails.env,
             response.request.method,
             uri.scheme,

--- a/spec/interceptors/caching/main_spec.rb
+++ b/spec/interceptors/caching/main_spec.rb
@@ -47,7 +47,7 @@ describe LHC::Caching do
 
   it 'lets you configure the cache key that will be used' do
     LHC.config.endpoint(:local, 'http://local.ch', cache: { key: 'STATICKEY' })
-    expect(Rails.cache).to receive(:fetch).with("LHC_CACHE(v#{LHC::Caching::CACHE_VERSION}): STATICKEY").and_call_original
+    expect(Rails.cache).to receive(:fetch).at_least(:once).with("LHC_CACHE(v#{LHC::Caching::CACHE_VERSION}): STATICKEY").and_call_original
     expect(Rails.cache).to receive(:write).with("LHC_CACHE(v#{LHC::Caching::CACHE_VERSION}): STATICKEY", anything, anything).and_call_original
     stub
     LHC.get(:local)
@@ -66,8 +66,8 @@ describe LHC::Caching do
     stub
     LHC.config.endpoint(:local, 'http://local.ch', cache: true)
     original_response = LHC.get(:local)
-    cached_response = LHC.get(:local)
     expect(original_response.from_cache?).to eq false
+    cached_response = LHC.get(:local)
     expect(cached_response.from_cache?).to eq true
   end
 end

--- a/spec/interceptors/caching/multilevel_cache_spec.rb
+++ b/spec/interceptors/caching/multilevel_cache_spec.rb
@@ -62,9 +62,8 @@ describe LHC::Caching do
 
     context 'found in central cache' do
       it 'serves it from central cache if found there' do
-        expect(redis_cache).to receive(:fetch).and_return(nil, {
-          body: '<h1>Hi there</h1>', code: 200, headers: nil, return_code: nil, mock: :webmock
-        })
+        expect(redis_cache).to receive(:fetch).and_return(nil,
+                                                            body: '<h1>Hi there</h1>', code: 200, headers: nil, return_code: nil, mock: :webmock)
         expect(redis_cache).to receive(:write).and_return(true)
         expect(Rails.cache).to receive(:fetch).and_call_original
         expect(Rails.cache).to receive(:write).and_call_original

--- a/spec/interceptors/caching/multilevel_cache_spec.rb
+++ b/spec/interceptors/caching/multilevel_cache_spec.rb
@@ -62,7 +62,9 @@ describe LHC::Caching do
 
     context 'found in central cache' do
       it 'serves it from central cache if found there' do
-        expect(redis_cache).to receive(:fetch).and_return(nil, body: '<h1>Hi there</h1>', code: 200, headers: nil, return_code: nil, mock: :webmock)
+        expect(redis_cache).to receive(:fetch).and_return(nil, {
+          body: '<h1>Hi there</h1>', code: 200, headers: nil, return_code: nil, mock: :webmock
+        })
         expect(redis_cache).to receive(:write).and_return(true)
         expect(Rails.cache).to receive(:fetch).and_call_original
         expect(Rails.cache).to receive(:write).and_call_original

--- a/spec/interceptors/monitoring/caching_spec.rb
+++ b/spec/interceptors/monitoring/caching_spec.rb
@@ -28,7 +28,6 @@ describe LHC::Monitoring do
     end
 
     context 'requesting with cache option' do
-
       it 'monitors miss/hit for caching' do
         stub
         expect(Statsd).to receive(:count).with('lhc.dummy.test.local_ch.get.cache.miss', 1)
@@ -39,7 +38,6 @@ describe LHC::Monitoring do
     end
 
     context 'request uncached' do
-
       it 'requesting without cache option' do
         stub
         expect(Statsd).not_to receive(:count).with('lhc.dummy.test.local_ch.get.cache.miss', 1)
@@ -59,7 +57,7 @@ describe LHC::Monitoring do
       stub
       expect(Statsd).not_to receive(:count).with('lhc.dummy.test.local_ch.get.cache.miss', 1)
       expect(Statsd).not_to receive(:count).with('lhc.dummy.test.local_ch.get.cache.hit', 1)
-      expect(->{
+      expect(-> {
         LHC.get('http://local.ch', cache: true)
         LHC.get('http://local.ch', cache: true)
       }).to output("[WARNING] Your interceptors must include LHC::Caching and LHC::Monitoring and also in that order.\n[WARNING] Your interceptors must include LHC::Caching and LHC::Monitoring and also in that order.\n").to_stderr

--- a/spec/interceptors/monitoring/caching_spec.rb
+++ b/spec/interceptors/monitoring/caching_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LHC::Monitoring do
+  let(:stub) do
+    stub_request(:get, 'http://local.ch').to_return(status: 200, body: 'The Website')
+  end
+
+  module Statsd
+    def self.count(_path, _value); end
+
+    def self.timing(_path, _value); end
+  end
+
+  before(:each) do
+    LHC::Monitoring.statsd = Statsd
+    Rails.cache.clear
+    allow(Statsd).to receive(:count).with('lhc.dummy.test.local_ch.get.before_request', 1)
+    allow(Statsd).to receive(:count).with('lhc.dummy.test.local_ch.get.count', 1)
+    allow(Statsd).to receive(:count).with('lhc.dummy.test.local_ch.get.after_request', 1)
+    allow(Statsd).to receive(:count).with('lhc.dummy.test.local_ch.get.200', 1)
+  end
+
+  context 'interceptors configured correctly' do
+    before do
+      LHC.config.interceptors = [LHC::Caching, LHC::Monitoring]
+    end
+
+    context 'requesting with cache option' do
+
+      it 'monitors miss/hit for caching' do
+        stub
+        expect(Statsd).to receive(:count).with('lhc.dummy.test.local_ch.get.cache.miss', 1)
+        expect(Statsd).to receive(:count).with('lhc.dummy.test.local_ch.get.cache.hit', 1)
+        LHC.get('http://local.ch', cache: true)
+        LHC.get('http://local.ch', cache: true)
+      end
+    end
+
+    context 'request uncached' do
+
+      it 'requesting without cache option' do
+        stub
+        expect(Statsd).not_to receive(:count).with('lhc.dummy.test.local_ch.get.cache.miss', 1)
+        expect(Statsd).not_to receive(:count).with('lhc.dummy.test.local_ch.get.cache.hit', 1)
+        LHC.get('http://local.ch')
+        LHC.get('http://local.ch')
+      end
+    end
+  end
+
+  context 'wrong interceptor order' do
+    before(:each) do
+      LHC.config.interceptors = [LHC::Monitoring, LHC::Caching] # monitoring needs to be after Caching
+    end
+
+    it 'does monitors miss/hit for caching and warns about wrong order of interceptors' do
+      stub
+      expect(Statsd).not_to receive(:count).with('lhc.dummy.test.local_ch.get.cache.miss', 1)
+      expect(Statsd).not_to receive(:count).with('lhc.dummy.test.local_ch.get.cache.hit', 1)
+      expect(->{
+        LHC.get('http://local.ch', cache: true)
+        LHC.get('http://local.ch', cache: true)
+      }).to output("[WARNING] Your interceptors must include LHC::Caching and LHC::Monitoring and also in that order.\n[WARNING] Your interceptors must include LHC::Caching and LHC::Monitoring and also in that order.\n").to_stderr
+    end
+  end
+end

--- a/spec/interceptors/response_competition_spec.rb
+++ b/spec/interceptors/response_competition_spec.rb
@@ -12,7 +12,7 @@ describe LHC do
 
         def before_request
           if @@cached
-            return LHC::Response.new(Typhoeus::Response.new(response_body: 'Im served from local cache'), nil)
+            return LHC::Response.new(Typhoeus::Response.new(response_code: 200, return_code: :ok, response_body: 'Im served from local cache'), nil)
           end
         end
       end
@@ -22,7 +22,7 @@ describe LHC do
 
         def before_request
           if request.response.nil?
-            return LHC::Response.new(Typhoeus::Response.new(response_body: 'Im served from remote cache'), nil)
+            return LHC::Response.new(Typhoeus::Response.new(response_code: 200, return_code: :ok, response_body: 'Im served from remote cache'), nil)
           end
         end
       end

--- a/spec/interceptors/return_response_spec.rb
+++ b/spec/interceptors/return_response_spec.rb
@@ -23,7 +23,7 @@ describe LHC do
       before(:each) do
         class AnotherInterceptor < LHC::Interceptor
           def before_request
-            LHC::Response.new(Typhoeus::Response.new({response_code: 200, return_code: :ok}), nil)
+            LHC::Response.new(Typhoeus::Response.new(response_code: 200, return_code: :ok), nil)
           end
         end
       end

--- a/spec/interceptors/return_response_spec.rb
+++ b/spec/interceptors/return_response_spec.rb
@@ -8,7 +8,7 @@ describe LHC do
       class CacheInterceptor < LHC::Interceptor
 
         def before_request
-          LHC::Response.new(Typhoeus::Response.new(response_body: 'Im served from cache'), nil)
+          LHC::Response.new(Typhoeus::Response.new(response_code: 200, return_code: :ok, response_body: 'Im served from cache'), nil)
         end
       end
       LHC.configure { |c| c.interceptors = [CacheInterceptor] }
@@ -23,7 +23,7 @@ describe LHC do
       before(:each) do
         class AnotherInterceptor < LHC::Interceptor
           def before_request
-            LHC::Response.new(Typhoeus::Response.new({}), nil)
+            LHC::Response.new(Typhoeus::Response.new({response_code: 200, return_code: :ok}), nil)
           end
         end
       end


### PR DESCRIPTION
This Introduces monitoring for caching.

It extends the monitoring interceptor to record `miss` or `hit` in order to monitor http caching.

Also:
- Fixes some `module_parent_name` calls to improve support of active support 5 and 6 and to get rid of some warnings
- Fixes a bug where interceptors `after_response` was not called, if a response was served from cache