### PR TITLE
Release 13.2.0.

### DIFF
--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '13.1.0'
+  VERSION ||= '13.2.0'
 end


### PR DESCRIPTION
# Description
Release with fixed warning `URI.escape is obsolete` mentioned here: https://github.com/local-ch/lhc/issues/193