### PR TITLE
Simplify GitHub Actions

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,6 +1,6 @@
 name: Rubocop
 
-on: push
+on: [push, pull_request]
 
 jobs:
   rubocop:
@@ -8,20 +8,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
-      - name: Cache Ruby Gems
-        uses: actions/cache@v2
-        with:
-          path: /.tmp/vendor/bundle
-          key: ${{ runner.os }}-gems-latest-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-latest-
-      - name: Bundle Install
-        run: |
-          bundle config path /.tmp/vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
       - name: Run Rubocop
-        run: |
-          bundle exec rubocop
+        run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: push
+on: [push, pull_request]
 
 jobs:
   rspec:
@@ -8,20 +8,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
-      - name: Cache Ruby Gems
-        uses: actions/cache@v2
-        with:
-          path: /.tmp/vendor/bundle
-          key: ${{ runner.os }}-gems-latest-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-latest-
-      - name: Bundle Install
-        run: |
-          bundle config path /.tmp/vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
       - name: Run Tests
-        run: |
-          bundle exec rspec
+        run: bundle exec rspec


### PR DESCRIPTION
Hey there 👋🏼 

This PR simplifies the GitHub Actions used in `lhc`. The same can probably be applied to `lhs` if you like.

The `ruby/setup-ruby` GitHub Action is way more superior than `actions/setup-ruby`.

It has built-in bundler cache, supports way more Ruby versions and uses the Ruby version defined in `.ruby-version` plus makes the actions a lot simpler 😊 
