### PR TITLE
Correct release version of latest release

### DIFF
--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '13.3.0'
+  VERSION ||= '14.0.0'
 end


### PR DESCRIPTION
In the last release we force the consumers of this gem to use at least ruby version 2.7.
This would have needed to be a major instead of a minor release.
With this PR we are going to create a major release. Afterwards i will yank the wrong version from ruby gems and delete the release from Github so in the end the major release is left.

Wrong release:
https://github.com/local-ch/lhc/releases/tag/v13.3.0