### PR TITLE
Fix `FrozenError (can't modify frozen String: "[FILTERED]")`

### DIFF
--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -63,19 +63,21 @@ class LHC::Request
   end
 
   def scrubbed_params
+    binding.pry
     LHC::ParamsScrubber.new(params.deep_dup).scrubbed
   end
 
   def scrubbed_headers
+    binding.pry
     LHC::HeadersScrubber.new(headers.deep_dup, options[:auth]).scrubbed
   end
 
   def scrubbed_options
     scrubbed_options = options.deep_dup
-    scrubbed_options[:params] = LHC::ParamsScrubber.new(scrubbed_options[:params]).scrubbed
-    scrubbed_options[:headers] = LHC::HeadersScrubber.new(scrubbed_options[:headers], scrubbed_options[:auth]).scrubbed
-    scrubbed_options[:auth] = LHC::AuthScrubber.new(scrubbed_options[:auth]).scrubbed
-    scrubbed_options[:body] = LHC::BodyScrubber.new(scrubbed_options[:body]).scrubbed
+    # scrubbed_options[:params] = LHC::ParamsScrubber.new(scrubbed_options[:params]).scrubbed
+    # scrubbed_options[:headers] = LHC::HeadersScrubber.new(scrubbed_options[:headers], scrubbed_options[:auth]).scrubbed
+    # scrubbed_options[:auth] = LHC::AuthScrubber.new(scrubbed_options[:auth]).scrubbed
+    # scrubbed_options[:body] = LHC::BodyScrubber.new(scrubbed_options[:body]).scrubbed
     scrubbed_options
   end
 

--- a/lib/lhc/request.rb
+++ b/lib/lhc/request.rb
@@ -63,21 +63,19 @@ class LHC::Request
   end
 
   def scrubbed_params
-    binding.pry
     LHC::ParamsScrubber.new(params.deep_dup).scrubbed
   end
 
   def scrubbed_headers
-    binding.pry
     LHC::HeadersScrubber.new(headers.deep_dup, options[:auth]).scrubbed
   end
 
   def scrubbed_options
     scrubbed_options = options.deep_dup
-    # scrubbed_options[:params] = LHC::ParamsScrubber.new(scrubbed_options[:params]).scrubbed
-    # scrubbed_options[:headers] = LHC::HeadersScrubber.new(scrubbed_options[:headers], scrubbed_options[:auth]).scrubbed
-    # scrubbed_options[:auth] = LHC::AuthScrubber.new(scrubbed_options[:auth]).scrubbed
-    # scrubbed_options[:body] = LHC::BodyScrubber.new(scrubbed_options[:body]).scrubbed
+    scrubbed_options[:params] = LHC::ParamsScrubber.new(scrubbed_options[:params]).scrubbed
+    scrubbed_options[:headers] = LHC::HeadersScrubber.new(scrubbed_options[:headers], scrubbed_options[:auth]).scrubbed
+    scrubbed_options[:auth] = LHC::AuthScrubber.new(scrubbed_options[:auth]).scrubbed
+    scrubbed_options[:body] = LHC::BodyScrubber.new(scrubbed_options[:body]).scrubbed
     scrubbed_options
   end
 

--- a/lib/lhc/scrubbers/headers_scrubber.rb
+++ b/lib/lhc/scrubbers/headers_scrubber.rb
@@ -4,9 +4,7 @@ class LHC::HeadersScrubber < LHC::Scrubber
   def initialize(data, auth_options)
     super(data)
     @auth_options = auth_options
-    binding.pry
     scrub!
-    binding.pry
     scrub_auth_headers!
   end
 
@@ -27,15 +25,26 @@ class LHC::HeadersScrubber < LHC::Scrubber
   end
 
   def scrub_basic_authentication_headers!
-    return if auth_options[:basic].blank? || scrubbed['Authorization'].blank?
+    return if !scrub_basic_authentication_headers?
 
     scrubbed['Authorization'].gsub!(auth_options[:basic][:base_64_encoded_credentials], SCRUB_DISPLAY)
   end
 
   def scrub_bearer_authentication_headers!
-    return if auth_options[:bearer].blank? || scrubbed['Authorization'].blank?
+    return if !scrub_bearer_authentication_headers?
 
-    binding.pry
     scrubbed['Authorization'].gsub!(auth_options[:bearer_token], SCRUB_DISPLAY)
+  end
+
+  def scrub_basic_authentication_headers?
+    auth_options[:basic].present? &&
+      scrubbed['Authorization'].present? &&
+      scrubbed['Authorization'].include?(auth_options[:basic][:base_64_encoded_credentials])
+  end
+
+  def scrub_bearer_authentication_headers?
+    auth_options[:bearer].present? &&
+      scrubbed['Authorization'].present? &&
+      scrubbed['Authorization'].include?(auth_options[:bearer_token])
   end
 end

--- a/lib/lhc/scrubbers/headers_scrubber.rb
+++ b/lib/lhc/scrubbers/headers_scrubber.rb
@@ -4,7 +4,9 @@ class LHC::HeadersScrubber < LHC::Scrubber
   def initialize(data, auth_options)
     super(data)
     @auth_options = auth_options
+    binding.pry
     scrub!
+    binding.pry
     scrub_auth_headers!
   end
 
@@ -33,6 +35,7 @@ class LHC::HeadersScrubber < LHC::Scrubber
   def scrub_bearer_authentication_headers!
     return if auth_options[:bearer].blank? || scrubbed['Authorization'].blank?
 
+    binding.pry
     scrubbed['Authorization'].gsub!(auth_options[:bearer_token], SCRUB_DISPLAY)
   end
 end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '15.0.0'
+  VERSION ||= '15.0.1'
 end

--- a/spec/request/scrubbed_headers_spec.rb
+++ b/spec/request/scrubbed_headers_spec.rb
@@ -4,8 +4,7 @@ require 'rails_helper'
 
 describe LHC::Request do
   let(:headers) { { private_key: 'xyz-123' } }
-  let(:response) { binding.pry; 
-                   LHC.get(:local, headers: headers) }
+  let(:response) { LHC.get(:local, headers: headers) }
   let(:auth) { {} }
 
   before :each do
@@ -67,7 +66,8 @@ describe LHC::Request do
 
       it 'scrubs whole "Authorization" header' do
         LHC.config.scrubs[:headers] << 'Authorization'
-        expect(request.scrubbed_headers).to include('Authorization' => "#{LHC::Scrubber::SCRUB_DISPLAY}")
+        expect(request.scrubbed_headers).to include('Authorization' => LHC::Scrubber::SCRUB_DISPLAY)
+        expect(request.headers).to include(authorization_header)
       end
 
       it 'scrubs nothing' do
@@ -90,7 +90,8 @@ describe LHC::Request do
 
       it 'scrubs whole "Authorization" header' do
         LHC.config.scrubs[:headers] << 'Authorization'
-        expect(request.scrubbed_headers).to include(authorization_header)
+        expect(request.scrubbed_headers).to include('Authorization' => LHC::Scrubber::SCRUB_DISPLAY)
+        expect(request.headers).to include(authorization_header)
       end
 
       it 'scrubs nothing' do

--- a/spec/request/scrubbed_headers_spec.rb
+++ b/spec/request/scrubbed_headers_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 describe LHC::Request do
   let(:headers) { { private_key: 'xyz-123' } }
-  let(:response) { LHC.get(:local, headers: headers) }
+  let(:response) { binding.pry; 
+                   LHC.get(:local, headers: headers) }
   let(:auth) { {} }
 
   before :each do
@@ -59,19 +60,19 @@ describe LHC::Request do
       let(:authorization_header) { { 'Authorization' => "Bearer #{bearer_token}" } }
       let(:auth) { { bearer: -> { bearer_token } } }
 
-      it 'provides srubbed request headers' do
+      it 'scrubs onlye the bearer token' do
         expect(request.scrubbed_headers).to include('Authorization' => "Bearer #{LHC::Scrubber::SCRUB_DISPLAY}")
         expect(request.headers).to include(authorization_header)
       end
 
-      context 'when nothing should get scrubbed' do
-        before :each do
-          LHC.config.scrubs = {}
-        end
+      it 'scrubs whole "Authorization" header' do
+        LHC.config.scrubs[:headers] << 'Authorization'
+        expect(request.scrubbed_headers).to include('Authorization' => "#{LHC::Scrubber::SCRUB_DISPLAY}")
+      end
 
-        it 'does not filter beaerer auth' do
-          expect(request.scrubbed_headers).to include(authorization_header)
-        end
+      it 'scrubs nothing' do
+        LHC.config.scrubs = {}
+        expect(request.scrubbed_headers).to include(authorization_header)
       end
     end
 
@@ -82,19 +83,19 @@ describe LHC::Request do
       let(:authorization_header) { { 'Authorization' => "Basic #{credentials_base_64_codiert}" } }
       let(:auth) { { basic: { username: username, password: password } } }
 
-      it 'provides srubbed request headers' do
+      it 'scrubs only credentials' do
         expect(request.scrubbed_headers).to include('Authorization' => "Basic #{LHC::Scrubber::SCRUB_DISPLAY}")
         expect(request.headers).to include(authorization_header)
       end
 
-      context 'when nothing should get scrubbed' do
-        before :each do
-          LHC.config.scrubs = {}
-        end
+      it 'scrubs whole "Authorization" header' do
+        LHC.config.scrubs[:headers] << 'Authorization'
+        expect(request.scrubbed_headers).to include(authorization_header)
+      end
 
-        it 'does not filter basic auth' do
-          expect(request.scrubbed_headers).to include(authorization_header)
-        end
+      it 'scrubs nothing' do
+        LHC.config.scrubs = {}
+        expect(request.scrubbed_headers).to include(authorization_header)
       end
     end
   end

--- a/spec/request/scrubbed_headers_spec.rb
+++ b/spec/request/scrubbed_headers_spec.rb
@@ -59,7 +59,7 @@ describe LHC::Request do
       let(:authorization_header) { { 'Authorization' => "Bearer #{bearer_token}" } }
       let(:auth) { { bearer: -> { bearer_token } } }
 
-      it 'scrubs onlye the bearer token' do
+      it 'scrubs only the bearer token' do
         expect(request.scrubbed_headers).to include('Authorization' => "Bearer #{LHC::Scrubber::SCRUB_DISPLAY}")
         expect(request.headers).to include(authorization_header)
       end


### PR DESCRIPTION
When the main app does a request either with bearer of or basic auth and the LHC config does scrub the whole header `config.scrubs[:headers] << 'Authorization' ` then we run into `FrozenError (can't modify frozen String: "[FILTERED]")`.

The problem is that we want to `.gsub!` a string which was already filtered before and that then causes the error.

This PR fixes that and makes sure to scrub only auth headers which are not already scrubbed.