### PR TITLE
Fix issue with parameter scrubbing

### DIFF
--- a/lib/lhc/scrubbers/cache_scrubber.rb
+++ b/lib/lhc/scrubbers/cache_scrubber.rb
@@ -19,8 +19,10 @@ class LHC::CacheScrubber < LHC::Scrubber
     return if scrubbed[:key].blank?
 
     scrub_elements.each do |scrub_element|
-      # binding.pry
-      value = scrubbed[:key].match(/:#{scrub_element}=>"(.*?)"/)[-1]
+      matches = scrubbed[:key].match(/:#{scrub_element}=>"(.*?)"/)
+      next if matches.nil?
+
+      value = matches[-1]
       scrubbed[:key].gsub!(value, SCRUB_DISPLAY)
     end
   end

--- a/lib/lhc/scrubbers/cache_scrubber.rb
+++ b/lib/lhc/scrubbers/cache_scrubber.rb
@@ -19,6 +19,7 @@ class LHC::CacheScrubber < LHC::Scrubber
     return if scrubbed[:key].blank?
 
     scrub_elements.each do |scrub_element|
+      # binding.pry
       value = scrubbed[:key].match(/:#{scrub_element}=>"(.*?)"/)[-1]
       scrubbed[:key].gsub!(value, SCRUB_DISPLAY)
     end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '15.1.0'
+  VERSION ||= '15.1.1'
 end

--- a/spec/request/scrubbed_options_spec.rb
+++ b/spec/request/scrubbed_options_spec.rb
@@ -58,6 +58,19 @@ describe LHC::Request do
     end
   end
 
+  context 'when parameter should not get scrubbed' do
+    let(:params) { { any_parameter: 'any-parameter' } }
+
+    let(:cache) do
+      { key: "LHS_REQUEST_CYCLE_CACHE(v1) POST http://local.ch?#{params}" }
+    end
+
+    it 'does not scrubb the parameter' do
+      expect(request.scrubbed_options[:cache])
+        .to include(key: "LHS_REQUEST_CYCLE_CACHE(v1) POST http://local.ch?#{params}")
+    end
+  end
+
   context 'when body data is nested' do
     let(:body) do
       {


### PR DESCRIPTION
When a request url did include a parmater which did not match any provided parameter to be scrubbed, then the app ran into:
```
expected LHC::NotFound, got #<NoMethodError: undefined method `[]' for nil:NilClass>
```
This PR fixes that.