### PR TITLE
[LCL-2447] - Fix re-authentication for the endpoints without auth options.

### DIFF
--- a/lib/lhc/interceptors/auth.rb
+++ b/lib/lhc/interceptors/auth.rb
@@ -50,9 +50,9 @@ class LHC::Auth < LHC::Interceptor
   end
 
   def set_bearer_authorization_header(token)
-    auth_options = request.options[:auth] || Hash.new
+    auth_options = request.options[:auth] || {}
     auth_options.merge!(bearer_token: token)
-    request.options[:auth] = auth_options unless request.options.has_key?(:auth)
+    request.options[:auth] = auth_options unless request.options.key?(:auth)
 
     set_authorization_header("Bearer #{token}")
   end

--- a/lib/lhc/interceptors/auth.rb
+++ b/lib/lhc/interceptors/auth.rb
@@ -50,7 +50,10 @@ class LHC::Auth < LHC::Interceptor
   end
 
   def set_bearer_authorization_header(token)
-    request.options[:auth].merge!(bearer_token: token)
+    auth_options = request.options[:auth] || Hash.new
+    auth_options.merge!(bearer_token: token)
+    request.options[:auth] = auth_options unless request.options.has_key?(:auth)
+
     set_authorization_header("Bearer #{token}")
   end
   # rubocop:enable Style/AccessorMethodName

--- a/lib/lhc/interceptors/rollbar.rb
+++ b/lib/lhc/interceptors/rollbar.rb
@@ -7,7 +7,7 @@ class LHC::Rollbar < LHC::Interceptor
   include LHC::FixInvalidEncodingConcern
 
   def after_response
-    return unless Object.const_defined?('Rollbar')
+    return unless Object.const_defined?(:Rollbar)
     return if response.success?
 
     request = response.request

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '15.1.2'
+  VERSION ||= '15.1.3'
 end

--- a/spec/interceptors/auth/reauthentication_spec.rb
+++ b/spec/interceptors/auth/reauthentication_spec.rb
@@ -27,6 +27,27 @@ describe LHC::Auth do
     expect(auth_suceeding_after_recovery).to have_been_made.once
   end
 
+  context 'without `auth` options' do
+    let(:headers) do
+      { 'Authorization' => "Bearer #{initial_token}" }
+    end
+
+    before do
+      LHC::Auth.refresh_client_token = -> { refresh_token }
+    end
+
+    after do
+      LHC::Auth.refresh_client_token = -> { nil }
+    end
+
+    it 'recovery is attempted' do
+      LHC.config.endpoint(:local, 'http://local.ch')
+      # the retried request (with updated Bearer), that should work
+      LHC.get(:local, { headers: headers })
+      expect(auth_suceeding_after_recovery).to have_been_made.once
+    end
+  end
+
   it "recovery is not attempted again when the request has reauthenticated: true " do
     LHC.config.endpoint(:local, 'http://local.ch', auth: options.merge(reauthenticated: true))
     expect { LHC.get(:local) }.to raise_error(LHC::Unauthorized)

--- a/spec/interceptors/rollbar/main_spec.rb
+++ b/spec/interceptors/rollbar/main_spec.rb
@@ -9,7 +9,7 @@ describe LHC::Rollbar do
 
   context 'Rollbar is undefined' do
     before(:each) do
-      Object.send(:remove_const, 'Rollbar') if Object.const_defined?('Rollbar')
+      Object.send(:remove_const, 'Rollbar') if Object.const_defined?(:Rollbar)
     end
     it 'does not report' do
       stub_request(:get, 'http://local.ch').to_return(status: 400)


### PR DESCRIPTION
# Ticket
https://jira.localsearch.ch/browse/LCL-2447

# Description
Starting from the release 15.0.0 re-authentication mechanism doesn't work properly for the endpoints without "auth" options. This PR fixes it.