### PR TITLE
Add sprockets-rails gem as a dev dependency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,9 @@ require:
 Bundler/OrderedGems:
   Enabled: false
 
+Gemspec/RequireMFA:
+  Enabled: false
+
 Lint/SuppressedException:
   Exclude:
     - spec/**/*
@@ -260,12 +263,15 @@ Style/CaseLikeIf:
   Enabled: false
 
 Style/HashEachMethods:
-  Enabled: false 
+  Enabled: false
 
 Style/HashConversion: # (new in 1.10)
   Enabled: false
 
 Style/NilLambda: # (new in 1.3)
+  Enabled: false
+
+Style/OpenStructUse:
   Enabled: false
 
 RSpec/DescribeClass:

--- a/lhc.gemspec
+++ b/lhc.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 1.0'
   s.add_development_dependency 'rubocop-performance', '~> 1.0'
   s.add_development_dependency 'rubocop-rspec', '~> 1.26.0'
+  s.add_development_dependency 'sprockets-rails'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'webmock'
 

--- a/lib/lhc/interceptors/auth.rb
+++ b/lib/lhc/interceptors/auth.rb
@@ -39,7 +39,7 @@ class LHC::Auth < LHC::Interceptor
     set_bearer_authorization_header(token)
   end
 
-  # rubocop:disable Style/AccessorMethodName
+  # rubocop:disable Naming/AccessorMethodName
   def set_authorization_header(value)
     request.headers['Authorization'] = value
   end
@@ -53,7 +53,7 @@ class LHC::Auth < LHC::Interceptor
     request.options[:auth].merge!(bearer_token: token)
     set_authorization_header("Bearer #{token}")
   end
-  # rubocop:enable Style/AccessorMethodName
+  # rubocop:enable Naming/AccessorMethodName
 
   def reauthenticate!
     # refresh token and update header

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '15.1.1'
+  VERSION ||= '15.1.2'
 end


### PR DESCRIPTION
# Description
Since rails 7 `sprockets-rails` gem is an optional dependency. As our dummy app is using it, i added this gem to the list of development dependencies.

I also created the separate issue about the usage of `OpenStruct`: https://github.com/local-ch/lhc/issues/206