### PR TITLE
Do not report to rollbar ignored errors

### DIFF
--- a/lhc.gemspec
+++ b/lhc.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.description = 'LHC is an extended/advanced HTTP client. Implementing basic http-communication enhancements like interceptors, exception handling, format handling, accessing response data, configuring endpoints and placeholders and fully compatible, RFC-compliant URL-template support.'
 
   s.files        = `git ls-files`.split("\n")
-  s.test_files   = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ['lib']
 
   s.requirements << 'Ruby >= 2.0.0'

--- a/lhc.gemspec
+++ b/lhc.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Advanced HTTP Client for Ruby, fueled with interceptors'
   s.description = 'LHC is an extended/advanced HTTP client. Implementing basic http-communication enhancements like interceptors, exception handling, format handling, accessing response data, configuring endpoints and placeholders and fully compatible, RFC-compliant URL-template support.'
 
-  s.files        = `git ls-files`.split("\n")
+  s.files         = `git ls-files`.split("\n")
   s.require_paths = ['lib']
 
   s.requirements << 'Ruby >= 2.0.0'

--- a/lib/lhc/interceptors/rollbar.rb
+++ b/lib/lhc/interceptors/rollbar.rb
@@ -29,7 +29,7 @@ class LHC::Rollbar < LHC::Interceptor
     }.merge additional_params
     begin
       Rollbar.warning("Status: #{response.code} URL: #{request.url}", data)
-    rescue Encoding::UndefinedConversionError
+    rescue JSON::GeneratorError, Encoding::UndefinedConversionError
       sanitized_data = data.deep_transform_values { |value| self.class.fix_invalid_encoding(value) }
       Rollbar.warning("Status: #{response.code} URL: #{request.url}", sanitized_data)
     end

--- a/lib/lhc/interceptors/rollbar.rb
+++ b/lib/lhc/interceptors/rollbar.rb
@@ -8,7 +8,7 @@ class LHC::Rollbar < LHC::Interceptor
 
   def after_response
     return unless Object.const_defined?(:Rollbar)
-    return if response.success?
+    return unless report?
 
     request = response.request
     additional_params = request.options.fetch(:rollbar, {})
@@ -33,5 +33,14 @@ class LHC::Rollbar < LHC::Interceptor
       sanitized_data = data.deep_transform_values { |value| self.class.fix_invalid_encoding(value) }
       Rollbar.warning("Status: #{response.code} URL: #{request.url}", sanitized_data)
     end
+  end
+
+  private
+
+  def report?
+    return false if response.success?
+    return false if response.request.error_ignored?
+
+    true
   end
 end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '15.1.3'
+  VERSION ||= '15.2.0'
 end

--- a/spec/error/to_s_spec.rb
+++ b/spec/error/to_s_spec.rb
@@ -15,7 +15,7 @@ describe LHC::Error do
         expect { "#{valid} #{invalid}" }.to raise_error Encoding::CompatibilityError
       end
       it 'to_json on an array raises an error' do
-        expect { [valid, invalid].to_json }.to raise_error Encoding::UndefinedConversionError
+        expect { [valid, invalid].to_json }.to raise_error JSON::GeneratorError
       end
 
       it 'to_s on a hash does not raise an error' do
@@ -23,7 +23,7 @@ describe LHC::Error do
       end
 
       it 'to_json on a hash does raise an error' do
-        expect { { valid: valid, invalid: invalid }.to_json }.to raise_error Encoding::UndefinedConversionError
+        expect { { valid: valid, invalid: invalid }.to_json }.to raise_error JSON::GeneratorError
       end
     end
 


### PR DESCRIPTION
_MINOR_

Stop reporting to Rollbar if errors are explicitly ignored.
