### PR TITLE
Cover the case when there is a beaerer proc but no bearer token

### DIFF
--- a/lib/lhc/scrubbers/headers_scrubber.rb
+++ b/lib/lhc/scrubbers/headers_scrubber.rb
@@ -44,6 +44,7 @@ class LHC::HeadersScrubber < LHC::Scrubber
 
   def scrub_bearer_authentication_headers?
     auth_options[:bearer].present? &&
+      # auth_options[:bearer_token] &&
       scrubbed['Authorization'].present? &&
       scrubbed['Authorization'].include?(auth_options[:bearer_token])
   end

--- a/lib/lhc/scrubbers/headers_scrubber.rb
+++ b/lib/lhc/scrubbers/headers_scrubber.rb
@@ -44,7 +44,7 @@ class LHC::HeadersScrubber < LHC::Scrubber
 
   def scrub_bearer_authentication_headers?
     auth_options[:bearer].present? &&
-      # auth_options[:bearer_token] &&
+      auth_options[:bearer_token] &&
       scrubbed['Authorization'].present? &&
       scrubbed['Authorization'].include?(auth_options[:bearer_token])
   end

--- a/lib/lhc/version.rb
+++ b/lib/lhc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHC
-  VERSION ||= '15.2.0'
+  VERSION ||= '15.2.1'
 end

--- a/spec/request/scrubbed_headers_spec.rb
+++ b/spec/request/scrubbed_headers_spec.rb
@@ -74,6 +74,14 @@ describe LHC::Request do
         LHC.config.scrubs = {}
         expect(request.scrubbed_headers).to include(authorization_header)
       end
+
+      context 'when the bearer_token is nil' do
+        let(:bearer_token) { nil }
+
+        it 'scrubs nothing' do
+          expect(request.scrubbed_headers).to include(authorization_header)
+        end
+      end
     end
 
     context 'basic authentication' do


### PR DESCRIPTION
It seems that we have cases when there is a bearer proc but no bearer_token. So this PR is covering that case.